### PR TITLE
Revert to single namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"Cake\\Acl\\": "src",
-			"Cake\\Acl\\Test\\": "tests"
+			"Acl\\": "src",
+			"Acl\\Test\\": "tests"
 		}
 	}
 }

--- a/src/AclInterface.php
+++ b/src/AclInterface.php
@@ -11,7 +11,7 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl;
+namespace Acl;
 
 use Cake\Controller\Component;
 

--- a/src/Adapter/DbAcl.php
+++ b/src/Adapter/DbAcl.php
@@ -11,15 +11,13 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Adapter;
+namespace Acl\Adapter;
 
-use Cake\Acl\AclInterface;
-use Cake\Acl\Model\Table\PermissionsTable;
+use Acl\AclInterface;
 
 use Cake\Controller\Component;
 use Cake\Core\App;
 use Cake\ORM\TableRegistry;
-use Cake\Utility\Hash;
 
 /**
  * DbAcl implements an ACL control system in the database. ARO's and ACO's are
@@ -48,7 +46,7 @@ class DbAcl implements AclInterface {
 	public function __construct() {
 		$config = [];
 		if (!TableRegistry::exists('Permissions')) {
-			$config = ['className' => App::className('Cake/Acl.PermissionsTable', 'Model/Table')];
+			$config = ['className' => App::className('Acl.PermissionsTable', 'Model/Table')];
 		}
 		$this->Permission = TableRegistry::get('Permissions', $config);
 		$this->Aro = $this->Permission->Aros->target();

--- a/src/Adapter/IniAcl.php
+++ b/src/Adapter/IniAcl.php
@@ -11,9 +11,9 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Adapter;
+namespace Acl\Adapter;
 
-use Cake\Acl\AclInterface;
+use Acl\AclInterface;
 
 use Cake\Configure\Engine\IniConfig;
 use Cake\Controller\Component;

--- a/src/Adapter/PhpAcl.php
+++ b/src/Adapter/PhpAcl.php
@@ -13,9 +13,9 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Adapter;
+namespace Acl\Adapter;
 
-use Cake\Acl\AclInterface;
+use Acl\AclInterface;
 
 use Cake\Configure\Engine\PhpConfig;
 use Cake\Controller\Component;

--- a/src/Auth/ActionsAuthorize.php
+++ b/src/Auth/ActionsAuthorize.php
@@ -12,7 +12,7 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Auth;
+namespace Acl\Auth;
 
 use Cake\Auth\BaseAuthorize;
 use Cake\Network\Request;

--- a/src/Auth/CrudAuthorize.php
+++ b/src/Auth/CrudAuthorize.php
@@ -12,7 +12,7 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Auth;
+namespace Acl\Auth;
 
 use Cake\Auth\BaseAuthorize;
 use Cake\Controller\ComponentRegistry;

--- a/src/Console/Command/AclShell.php
+++ b/src/Console/Command/AclShell.php
@@ -11,9 +11,9 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Console\Command;
+namespace Acl\Console\Command;
 
-use Cake\Acl\Controller\Component\AclComponent;
+use Acl\Controller\Component\AclComponent;
 
 use Cake\Console\Shell;
 use Cake\Controller\ComponentRegistry;
@@ -69,10 +69,10 @@ class AclShell extends Shell {
 		}
 
 		$class = Configure::read('Acl.classname');
-		$className = App::classname('Cake/Acl.' . $class, 'Adapter');
+		$className = App::classname('Acl.' . $class, 'Adapter');
 		if (
 			$class !== 'DbAcl' &&
-			!is_subclass_of($className, 'Cake\Acl\Adapter\DbAcl')
+			!is_subclass_of($className, 'Acl\Adapter\DbAcl')
 		) {
 			$out = "--------------------------------------------------\n";
 			$out .= __d('cake_acl', 'Error: Your current CakePHP configuration is set to an ACL implementation other than DB.') . "\n";

--- a/src/Controller/Component/AclComponent.php
+++ b/src/Controller/Component/AclComponent.php
@@ -11,9 +11,9 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Controller\Component;
+namespace Acl\Controller\Component;
 
-use Cake\Acl\AclInterface;
+use Acl\AclInterface;
 
 use Cake\Configure\Engine\IniConfig;
 use Cake\Controller\Component;
@@ -67,7 +67,7 @@ class AclComponent extends Component {
 		parent::__construct($collection, $config);
 		$className = $name = Configure::read('Acl.classname');
 		if (!class_exists($className)) {
-			$className = App::className('Cake/Acl.' . $name, 'Adapter');
+			$className = App::className('Acl.' . $name, 'Adapter');
 			if (!$className) {
 				throw new Error\Exception(sprintf('Could not find %s.', $name));
 			}

--- a/src/Model/Behavior/AclBehavior.php
+++ b/src/Model/Behavior/AclBehavior.php
@@ -11,7 +11,7 @@
  * @link          http://cakephp.org CakePHP Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Model\Behavior;
+namespace Acl\Model\Behavior;
 
 use Cake\Core\App;
 use Cake\Error;
@@ -20,8 +20,6 @@ use Cake\ORM\Behavior;
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
-use Cake\Utility\ClassRegistry;
-use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 
 /**
@@ -72,7 +70,7 @@ class AclBehavior extends Behavior {
 			$alias = Inflector::pluralize($type);
 			$className = App::className($alias . 'Table', 'Model/Table');
 			if ($className == false) {
-				$className = App::className('Cake/Acl.' . $alias . 'Table', 'Model/Table');
+				$className = App::className('Acl.' . $alias . 'Table', 'Model/Table');
 			}
 			$config = [];
 			if (!TableRegistry::exists($alias)) {

--- a/src/Model/Entity/Aco.php
+++ b/src/Model/Entity/Aco.php
@@ -12,7 +12,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-namespace Cake\Acl\Model\Entity;
+namespace Acl\Model\Entity;
 
 use Cake\ORM\Entity;
 

--- a/src/Model/Entity/Aro.php
+++ b/src/Model/Entity/Aro.php
@@ -12,7 +12,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-namespace Cake\Acl\Model\Entity;
+namespace Acl\Model\Entity;
 
 use Cake\ORM\Entity;
 

--- a/src/Model/Entity/Permission.php
+++ b/src/Model/Entity/Permission.php
@@ -12,7 +12,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-namespace Cake\Acl\Model\Entity;
+namespace Acl\Model\Entity;
 
 use Cake\ORM\Entity;
 

--- a/src/Model/Table/AclNodesTable.php
+++ b/src/Model/Table/AclNodesTable.php
@@ -11,7 +11,7 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Model\Table;
+namespace Acl\Model\Table;
 
 use Cake\Core\App;
 use Cake\Core\Configure;

--- a/src/Model/Table/AcoActionsTable.php
+++ b/src/Model/Table/AcoActionsTable.php
@@ -11,7 +11,7 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Model\Table;
+namespace Acl\Model\Table;
 
 use Cake\ORM\Table;
 
@@ -29,7 +29,7 @@ class AcoActionsTable extends Table {
  */
 	public function initialize(array $config) {
 		$this->belongsTo('Acos', [
-			'className' => App::className('Cake/Acl.AcosTable', 'Model/Table'),
+			'className' => App::className('Acl.AcosTable', 'Model/Table'),
 		]);
 	}
 

--- a/src/Model/Table/AcosTable.php
+++ b/src/Model/Table/AcosTable.php
@@ -11,9 +11,9 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Model\Table;
+namespace Acl\Model\Table;
 
-use Cake\Acl\Model\Table\AclNodesTable;
+use Acl\Model\Table\AclNodesTable;
 
 use Cake\Core\App;
 
@@ -36,14 +36,14 @@ class AcosTable extends AclNodesTable {
 		$this->addBehavior('Tree', ['type' => 'nested']);
 
 		$this->belongsToMany('Aros', [
-			'through' => App::className('Cake/Acl.PermissionsTable', 'Model/Table'),
-			'className' => App::className('Cake/Acl.ArosTable', 'Model/Table'),
+			'through' => App::className('Acl.PermissionsTable', 'Model/Table'),
+			'className' => App::className('Acl.ArosTable', 'Model/Table'),
 		]);
 		$this->hasMany('AcoChildren', [
-			'className' => App::className('Cake/Acl.AcosTable', 'Model/Table'),
+			'className' => App::className('Acl.AcosTable', 'Model/Table'),
 			'foreignKey' => 'parent_id'
 		]);
-		$this->entityClass(App::className('Cake/Acl.Aco', 'Model/Entity'));
+		$this->entityClass(App::className('Acl.Aco', 'Model/Entity'));
 	}
 
 }

--- a/src/Model/Table/ArosTable.php
+++ b/src/Model/Table/ArosTable.php
@@ -11,9 +11,9 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Model\Table;
+namespace Acl\Model\Table;
 
-use Cake\Acl\Model\Table\AclNodesTable;
+use Acl\Model\Table\AclNodesTable;
 
 use Cake\Core\App;
 
@@ -36,15 +36,15 @@ class ArosTable extends AclNodesTable {
 		$this->addBehavior('Tree', ['type' => 'nested']);
 
 		$this->belongsToMany('Acos', [
-			'through' => App::className('Cake/Acl.PermissionsTable', 'Model/Table'),
-			'className' => App::className('Cake/Acl.AcosTable', 'Model/Table'),
+			'through' => App::className('Acl.PermissionsTable', 'Model/Table'),
+			'className' => App::className('Acl.AcosTable', 'Model/Table'),
 		]);
 		$this->hasMany('AroChildren', [
-			'className' => App::className('Cake/Acl.ArosTable', 'Model/Table'),
+			'className' => App::className('Acl.ArosTable', 'Model/Table'),
 			'foreignKey' => 'parent_id'
 		]);
 
-		$this->entityClass('Cake/Acl.Aro', 'Model/Entity');
+		$this->entityClass('Acl.Aro', 'Model/Entity');
 	}
 
 }

--- a/src/Model/Table/PermissionsTable.php
+++ b/src/Model/Table/PermissionsTable.php
@@ -11,7 +11,7 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Model\Table;
+namespace Acl\Model\Table;
 
 use Cake\Core\App;
 use Cake\Core\Configure;
@@ -35,10 +35,10 @@ class PermissionsTable extends AclNodesTable {
 		$this->alias('Permissions');
 		$this->table('aros_acos');
 		$this->belongsTo('Aros', [
-			'className' => App::className('Cake/Acl.ArosTable', 'Model/Table'),
+			'className' => App::className('Acl.ArosTable', 'Model/Table'),
 		]);
 		$this->belongsTo('Acos', [
-			'className' => App::className('Cake/Acl.AcosTable', 'Model/Table'),
+			'className' => App::className('Acl.AcosTable', 'Model/Table'),
 		]);
 		$this->Aro = $this->Aros->target();
 		$this->Aco = $this->Acos->target();

--- a/tests/Fixture/AcoActionFixture.php
+++ b/tests/Fixture/AcoActionFixture.php
@@ -11,7 +11,7 @@
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Test\Fixture;
+namespace Acl\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 

--- a/tests/Fixture/AcoFixture.php
+++ b/tests/Fixture/AcoFixture.php
@@ -11,7 +11,7 @@
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Test\Fixture;
+namespace Acl\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 

--- a/tests/Fixture/AcoTwoFixture.php
+++ b/tests/Fixture/AcoTwoFixture.php
@@ -11,7 +11,7 @@
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Test\Fixture;
+namespace Acl\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 

--- a/tests/Fixture/AroFixture.php
+++ b/tests/Fixture/AroFixture.php
@@ -11,7 +11,7 @@
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Test\Fixture;
+namespace Acl\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 

--- a/tests/Fixture/AroTwoFixture.php
+++ b/tests/Fixture/AroTwoFixture.php
@@ -11,7 +11,7 @@
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Test\Fixture;
+namespace Acl\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 

--- a/tests/Fixture/ArosAcoFixture.php
+++ b/tests/Fixture/ArosAcoFixture.php
@@ -11,7 +11,7 @@
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Test\Fixture;
+namespace Acl\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 

--- a/tests/Fixture/ArosAcoTwoFixture.php
+++ b/tests/Fixture/ArosAcoTwoFixture.php
@@ -11,7 +11,7 @@
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Test\Fixture;
+namespace Acl\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
 

--- a/tests/TestCase/Adapter/DbAclTest.php
+++ b/tests/TestCase/Adapter/DbAclTest.php
@@ -11,16 +11,16 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Test\TestCase\Adapter;
+namespace Acl\Test\TestCase\Adapter;
 
-use Cake\Acl\Adapter\DbAcl;
-use Cake\Acl\Controller\Component\AclComponent;
-use Cake\Acl\Model\Entity\Aco;
-use Cake\Acl\Model\Entity\Aro;
-use Cake\Acl\Model\Table\AclNodesTable;
-use Cake\Acl\Model\Table\AcosTable;
-use Cake\Acl\Model\Table\ArosTable;
-use Cake\Acl\Model\Table\PermissionsTable;
+use Acl\Adapter\DbAcl;
+use Acl\Controller\Component\AclComponent;
+use Acl\Model\Entity\Aco;
+use Acl\Model\Entity\Aro;
+use Acl\Model\Table\AclNodesTable;
+use Acl\Model\Table\AcosTable;
+use Acl\Model\Table\ArosTable;
+use Acl\Model\Table\PermissionsTable;
 
 use Cake\Controller\ComponentRegistry;
 use Cake\Core\Configure;
@@ -95,7 +95,7 @@ class PermissionTwoTest extends PermissionsTable {
 	public function initialize(array $config) {
 		parent::initialize($config);
 		$this->alias('PermissionTwoTest');
-		$this->entityClass('Cake\Acl\Model\Entity\Permission');
+		$this->entityClass('Acl\Model\Entity\Permission');
 		$this->table('aros_aco_twos');
 		$this->associations()->removeAll();
 		$this->belongsTo('AroTwoTest', [

--- a/tests/TestCase/Adapter/IniAclTest.php
+++ b/tests/TestCase/Adapter/IniAclTest.php
@@ -11,10 +11,10 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Test\TestCase\Adapter;
+namespace Acl\Test\TestCase\Adapter;
 
-use Cake\Acl\Adapter\IniAcl;
-use Cake\Acl\Controller\Component\AclComponent;
+use Acl\Adapter\IniAcl;
+use Acl\Controller\Component\AclComponent;
 
 use Cake\TestSuite\TestCase;
 

--- a/tests/TestCase/Adapter/PhpAclTest.php
+++ b/tests/TestCase/Adapter/PhpAclTest.php
@@ -11,11 +11,11 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Test\TestCase\Adapter;
+namespace Acl\Test\TestCase\Adapter;
 
-use Cake\Acl\Adapter\PhpAcl;
-use Cake\Acl\Adapter\PhpAro;
-use Cake\Acl\Controller\Component\AclComponent;
+use Acl\Adapter\PhpAcl;
+use Acl\Adapter\PhpAro;
+use Acl\Controller\Component\AclComponent;
 
 use Cake\Controller\ComponentRegistry;
 use Cake\Core\Configure;

--- a/tests/TestCase/Auth/ActionsAuthorizeTest.php
+++ b/tests/TestCase/Auth/ActionsAuthorizeTest.php
@@ -11,9 +11,9 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Test\TestCase\Auth;
+namespace Acl\Test\TestCase\Auth;
 
-use Cake\Acl\Auth\ActionsAuthorize;
+use Acl\Auth\ActionsAuthorize;
 
 use Cake\Network\Request;
 use Cake\TestSuite\TestCase;
@@ -32,7 +32,7 @@ class ActionsAuthorizeTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->controller = $this->getMock('Cake\Controller\Controller', array(), array(), '', false);
-		$this->Acl = $this->getMock('Cake\Acl\Controller\Component\AclComponent', array(), array(), '', false);
+		$this->Acl = $this->getMock('Acl\Controller\Component\AclComponent', array(), array(), '', false);
 		$this->Collection = $this->getMock('Cake\Controller\ComponentRegistry');
 
 		$this->auth = new ActionsAuthorize($this->Collection);

--- a/tests/TestCase/Auth/CrudAuthorizeTest.php
+++ b/tests/TestCase/Auth/CrudAuthorizeTest.php
@@ -11,9 +11,9 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Test\TestCase\Auth;
+namespace Acl\Test\TestCase\Auth;
 
-use Cake\Acl\Auth\CrudAuthorize;
+use Acl\Auth\CrudAuthorize;
 use Cake\Core\Configure;
 use Cake\Network\Request;
 use Cake\Routing\Router;
@@ -35,7 +35,7 @@ class CrudAuthorizeTest extends TestCase {
 		Configure::write('Routing.prefixes', array());
 		Router::reload();
 
-		$this->Acl = $this->getMock('Cake\Acl\Controller\Component\AclComponent', array(), array(), '', false);
+		$this->Acl = $this->getMock('Acl\Controller\Component\AclComponent', array(), array(), '', false);
 		$this->Components = $this->getMock('Cake\Controller\ComponentRegistry');
 
 		$this->auth = new CrudAuthorize($this->Components);

--- a/tests/TestCase/Controller/Component/AclComponentTest.php
+++ b/tests/TestCase/Controller/Component/AclComponentTest.php
@@ -11,9 +11,9 @@
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Test\TestCase\Controller\Component;
+namespace Acl\Test\TestCase\Controller\Component;
 
-use Cake\Acl\Controller\Component\AclComponent;
+use Acl\Controller\Component\AclComponent;
 
 use Cake\Controller\ComponentRegistry;
 use Cake\Core\Configure;
@@ -33,7 +33,7 @@ class AclComponentTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 		if (!class_exists('MockAclImplementation', false)) {
-			$this->getMock('Cake\Acl\AclInterface', array(), array(), 'MockAclImplementation');
+			$this->getMock('Acl\AclInterface', array(), array(), 'MockAclImplementation');
 		}
 		Configure::write('Acl.classname', '\MockAclImplementation');
 		$Collection = new ComponentRegistry();
@@ -69,7 +69,7 @@ class AclComponentTest extends TestCase {
  * @return void
  */
 	public function testAdapter() {
-		$Adapter = $this->getMock('Cake\Acl\AclInterface');
+		$Adapter = $this->getMock('Acl\AclInterface');
 		$Adapter->expects($this->once())->method('initialize')->with($this->Acl);
 
 		$this->assertNull($this->Acl->adapter($Adapter));

--- a/tests/TestCase/Model/Behavior/AclBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/AclBehaviorTest.php
@@ -13,12 +13,12 @@
  */
 namespace Cake\Auth\Test\TestCase\Model\Behavior;
 
-use Cake\Acl\Model\Behavior\AclBehavior;
-use Cake\Acl\Model\Entity\Aco;
-use Cake\Acl\Model\Entity\Aro;
-use Cake\Acl\Model\Table\AclNodesTable;
-use Cake\Acl\Model\Table\AcosTable;
-use Cake\Acl\Model\Table\ArosTable;
+use Acl\Model\Behavior\AclBehavior;
+use Acl\Model\Entity\Aco;
+use Acl\Model\Entity\Aro;
+use Acl\Model\Table\AclNodesTable;
+use Acl\Model\Table\AcosTable;
+use Acl\Model\Table\ArosTable;
 
 use Cake\Core\App;
 use Cake\Core\Configure;
@@ -186,10 +186,10 @@ class AclBehaviorTest extends TestCase {
 
 		TableRegistry::clear();
 		$this->Aco = TableRegistry::get('Acos', [
-			'className' => App::className('Cake/Acl.AcosTable', 'Model/Table'),
+			'className' => App::className('Acl.AcosTable', 'Model/Table'),
 		]);
 		$this->Aro = TableRegistry::get('Aros', [
-			'className' => App::className('Cake/Acl.ArosTable', 'Model/Table'),
+			'className' => App::className('Acl.ArosTable', 'Model/Table'),
 		]);
 
 		TableRegistry::get('AclUsers', [

--- a/tests/TestCase/Model/Table/AclNodesTest.php
+++ b/tests/TestCase/Model/Table/AclNodesTest.php
@@ -11,14 +11,14 @@
  * @link          http://book.cakephp.org/2.0/en/development/testing.html CakePHP(tm) Tests
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Acl\Test\TestCase\Model\Table;
+namespace Acl\Test\TestCase\Model\Table;
 
-use Cake\Acl\Adapter\DbAcl;
-use Cake\Acl\Model\Table\AclNodesTable;
-use Cake\Acl\Model\Table\AcoActionsTable;
-use Cake\Acl\Model\Table\AcosTable;
-use Cake\Acl\Model\Table\ArosTable;
-use Cake\Acl\Model\Table\PermissionsTable;
+use Acl\Adapter\DbAcl;
+use Acl\Model\Table\AclNodesTable;
+use Acl\Model\Table\AcoActionsTable;
+use Acl\Model\Table\AcosTable;
+use Acl\Model\Table\ArosTable;
+use Acl\Model\Table\PermissionsTable;
 
 use Cake\Core\App;
 use Cake\Core\Configure;
@@ -188,10 +188,10 @@ class AclNodeTest extends TestCase {
 
 		TableRegistry::clear();
 		TableRegistry::get('DbAcoTest', [
-			'className' => 'Cake\Acl\Test\TestCase\Model\Table\DbAcoTest',
+			'className' => 'Acl\Test\TestCase\Model\Table\DbAcoTest',
 		]);
 		TableRegistry::get('DbAroTest', [
-			'className' => 'Cake\Acl\Test\TestCase\Model\Table\DbAroTest',
+			'className' => 'Acl\Test\TestCase\Model\Table\DbAroTest',
 		]);
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -66,7 +66,7 @@ mb_internal_encoding('UTF-8');
 
 Configure::write('debug', true);
 Configure::write('App', [
-	'namespace' => 'Cake\Acl',
+	'namespace' => 'Acl',
 	'encoding' => 'UTF-8',
 	'base' => false,
 	'baseUrl' => false,


### PR DESCRIPTION
Removed the vendor namespace from the Acl plugin.

As specified in cakephp/cakephp#4236
