### PR TITLE
Remove initdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ In your `config\bootstrap.php`:
 Plugin::load('Acl', ['bootstrap' => true]);
 ```
 
+## Creating tables
+
+To create ACL related tables, run the following `Migrations` command:
+
+```
+bin/cake Migrations.migrations migrate -p Acl
+```
+
 ## Running tests
 
 Assuming you have PHPUnit installed system wide using one of the methods stated

--- a/src/Shell/AclExtrasShell.php
+++ b/src/Shell/AclExtrasShell.php
@@ -59,6 +59,18 @@ class AclExtrasShell extends Shell
         parent::startup();
         $this->AclExtras->startup();
         $this->AclExtras->Shell = $this;
+
+        if ($this->command) {
+            try {
+                \Cake\ORM\TableRegistry::get('Aros')->schema();
+            } catch (\Cake\Database\Exception $e) {
+                $this->out(__d('cake_acl', 'Acl database tables not found. To create them, run:'));
+                $this->out();
+                $this->out('  bin/cake Migrations.migrations migrate -p Acl');
+                $this->out();
+                return $this->_stop();
+            }
+        }
     }
 
 /**

--- a/src/Shell/AclShell.php
+++ b/src/Shell/AclShell.php
@@ -92,11 +92,9 @@ class AclShell extends Shell
                 return $this->DbConfig->execute();
             }
 
-            if (!in_array($this->command, ['initdb'])) {
-                $registry = new ComponentRegistry();
-                $this->Acl = new AclComponent($registry);
-                $controller = new Controller();
-            }
+            $registry = new ComponentRegistry();
+            $this->Acl = new AclComponent($registry);
+            $controller = new Controller();
         }
     }
 
@@ -361,16 +359,6 @@ class AclShell extends Shell
     }
 
     /**
-     * Initialize ACL database.
-     *
-     * @return mixed
-     */
-    public function initdb()
-    {
-        return $this->dispatchShell('schema create DbAcl');
-    }
-
-    /**
      * Gets the option parser instance and configures it.
      *
      * @return ConsoleOptionParser
@@ -508,8 +496,6 @@ class AclShell extends Shell
                     'node' => ['help' => __d('cake_acl', 'The optional node to view the subtree of.')]
                 ]
             ]
-        ])->addSubcommand('initdb', [
-            'help' => __d('cake_acl', 'Initialize the DbAcl tables. Uses this command : cake schema create DbAcl')
         ])->epilog(
             [
                 'Node and parent arguments can be in one of the following formats:',

--- a/src/Shell/AclShell.php
+++ b/src/Shell/AclShell.php
@@ -92,6 +92,16 @@ class AclShell extends Shell
                 return $this->DbConfig->execute();
             }
 
+            try {
+                \Cake\ORM\TableRegistry::get('Aros')->schema();
+            } catch (\Cake\Database\Exception $e) {
+                $this->out(__d('cake_acl', 'Acl database tables not found. To create them, run:'));
+                $this->out();
+                $this->out('  bin/cake Migrations.migrations migrate -p Acl');
+                $this->out();
+                return $this->_stop();
+            }
+
             $registry = new ComponentRegistry();
             $this->Acl = new AclComponent($registry);
             $controller = new Controller();


### PR DESCRIPTION
- Remove initdb
- Add small note on running migrations to create tables
- Catch missing table errors and display above note