### PR TITLE
fixes an other bunch of cs errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
 
 script:
   - sh -c "if [ '$PHPCS' != '1' ]; then phpunit; fi"
-  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p -n --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP . --ignore=vendor; fi"
+  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p -n --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,10 @@
 	},
 	"minimum-stability": "dev",
 	"require": {
-		"cakephp/cakephp": "~3.0",
-		"cakephp/plugin-installer": "*"
+		"cakephp/cakephp": "~3.0"
 	},
 	"require-dev": {
-		"cakephp/cakephp-codesniffer": "2.0.*-dev",
+		"cakephp/cakephp-codesniffer": "master-dev",
 		"phpunit/phpunit": "4.*"
 	},
 	"autoload": {

--- a/src/AclExtras.php
+++ b/src/AclExtras.php
@@ -129,7 +129,7 @@ class AclExtras
                 $this->err(__d('cake_acl', "<error>Plugin {0} not found or not activated.</error>", [$plugin]));
                 return false;
             }
-            $plugins = array($params['plugin']);
+            $plugins = [$params['plugin']];
         }
         foreach ($plugins as $plugin) {
             $controllers = $this->getControllerList($plugin);
@@ -158,7 +158,7 @@ class AclExtras
         }
         $appIndex = array_search($plugin . 'AppController', $controllers);
         // look at each controller
-        $controllersNames = array();
+        $controllersNames = [];
         foreach ($controllers as $controller) {
             $tmp = explode('/', $controller);
             $controllerName = str_replace('Controller.php', '', array_pop($tmp));
@@ -251,7 +251,7 @@ class AclExtras
      */
     protected function _getCallbacks($className, $pluginPath = false)
     {
-        $callbacks = array();
+        $callbacks = [];
         $namespace = $this->_getNamespace($className, $pluginPath);
         $reflection = new \ReflectionClass($namespace);
         if ($reflection->isAbstract()) {

--- a/src/AclExtras.php
+++ b/src/AclExtras.php
@@ -12,16 +12,16 @@
  */
 namespace Acl;
 
+use Acl\Controller\Component\AclComponent;
 use Cake\Console\ConsoleIo;
 use Cake\Console\Shell;
-use Acl\Controller\Component\AclComponent;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
-use Cake\Network\Request;
-use Cake\Core\Configure;
 use Cake\Core\App;
-use Cake\Utility\Inflector;
+use Cake\Core\Configure;
 use Cake\Filesystem\Folder;
+use Cake\Network\Request;
+use Cake\Utility\Inflector;
 
 /**
  * Shell for ACO extras
@@ -158,7 +158,7 @@ class AclExtras
         }
         $appIndex = array_search($plugin . 'AppController', $controllers);
         // look at each controller
-        $controllersNames=array();
+        $controllersNames = array();
         foreach ($controllers as $controller) {
             $tmp = explode('/', $controller);
             $controllerName = str_replace('Controller.php', '', array_pop($tmp));
@@ -175,16 +175,17 @@ class AclExtras
             }
             $controllerFlip = array_flip($controllers);
             $this->Aco->id = $root->id;
-            $controllerNodes = $this->Aco->find()->where(['parent_id'=>$root->id]);
+            $controllerNodes = $this->Aco->find()->where(['parent_id' => $root->id]);
             foreach ($controllerNodes as $ctrlNode) {
                 $alias = $ctrlNode->alias;
                 $name = $alias . 'Controller';
                 if (!isset($controllerFlip[$name]) && !isset($controllerFlip[$alias])) {
                     $entity = $this->Aco->get($ctrlNode->id);
                     if ($this->Aco->delete($entity)) {
-                        $this->out(__d('cake_acl',
+                        $this->out(__d(
+                            'cake_acl',
                             'Deleted <warning>{0}</warning> and all children',
-                            $this->rootNode . '/' .$plugin.'/'. $ctrlNode->alias
+                            $this->rootNode . '/' . $plugin . '/' . $ctrlNode->alias
                         ));
                     }
                 }
@@ -301,16 +302,16 @@ class AclExtras
         }
         $methods = array_diff($actions, $baseMethods);
         $methods = array_diff($methods, $excludes);
-        foreach ($methods as $key=>$action) {
+        foreach ($methods as $key => $action) {
             if (strpos($action, '_', 0) === 0) {
                 continue;
             }
-            $path = $this->rootNode . '/' . $pluginPath . $controllerName . '/' . $prefix.$action;
-            $this->_checkNode($path, $prefix.$action, $node->id);
-            $methods[$key]=$prefix.$action;
+            $path = $this->rootNode . '/' . $pluginPath . $controllerName . '/' . $prefix . $action;
+            $this->_checkNode($path, $prefix . $action, $node->id);
+            $methods[$key] = $prefix . $action;
         }
         if ($this->_clean) {
-            $actionNodes = $this->Aco->find('children', ['for'=>$node->id]);
+            $actionNodes = $this->Aco->find('children', ['for' => $node->id]);
             $methodFlip = array_flip($methods);
             foreach ($actionNodes as $action) {
                 if (!isset($methodFlip[$action->alias])) {
@@ -328,7 +329,6 @@ class AclExtras
     /**
      * Verify a Acl Tree
      *
-     * @param string $type The type of Acl Node to verify
      * @return void
      */
     public function verify()
@@ -346,7 +346,6 @@ class AclExtras
     /**
      * Recover an Acl Tree
      *
-     * @param string $type The Type of Acl Node to recover
      * @return void
      */
     public function recover()
@@ -389,9 +388,9 @@ class AclExtras
         if (empty($namespace)) {
             return null;
         }
-        $path_array = explode('\\', $namespace);
-        if (count($path_array) >= 5) {
-            return Inflector::dasherize($path_array[3]) . '_';
+        $pathArray = explode('\\', $namespace);
+        if (count($pathArray) >= 5) {
+            return Inflector::dasherize($pathArray[3]) . '_';
         }
         return null;
     }
@@ -408,5 +407,4 @@ class AclExtras
         $plugins = $dir->read();
         return $plugins[0];
     }
-
 }

--- a/src/Model/Table/AclNodesTable.php
+++ b/src/Model/Table/AclNodesTable.php
@@ -98,8 +98,7 @@ class AclNodesTable extends Table
             $result = $query->toArray();
             $path = array_values($path);
 
-            if (
-                !isset($result[0]) ||
+            if (!isset($result[0]) ||
                 (!empty($path) && $result[0]->alias != $path[count($path) - 1]) ||
                 (empty($path) && $result[0]->alias != $start)
             ) {

--- a/src/Shell/AclExtrasShell.php
+++ b/src/Shell/AclExtrasShell.php
@@ -14,10 +14,9 @@
  */
 namespace Acl\Shell;
 
-use Cake\Console\Shell;
-use Cake\Console\ConsoleIo;
 use Acl\AclExtras;
-
+use Cake\Console\ConsoleIo;
+use Cake\Console\Shell;
 
 /**
  * Shell for ACO extras
@@ -42,7 +41,7 @@ class AclExtrasShell extends Shell
     /**
      * Constructor
      *
-     * @param \Cake\Console\ConsoleIo $io
+     * @param \Cake\Console\ConsoleIo $io An io instance.
      */
     public function __construct(ConsoleIo $io = null)
     {
@@ -150,7 +149,6 @@ class AclExtrasShell extends Shell
     /**
      * Verify a Acl Tree
      *
-     * @param string $type The type of Acl Node to verify
      * @return void
      */
     public function verify()
@@ -162,7 +160,6 @@ class AclExtrasShell extends Shell
     /**
      * Recover an Acl Tree
      *
-     * @param string $type The Type of Acl Node to recover
      * @return void
      */
     public function recover()
@@ -170,5 +167,4 @@ class AclExtrasShell extends Shell
         $this->AclExtras->args = $this->args;
         $this->AclExtras->recover();
     }
-
 }

--- a/src/Shell/AclShell.php
+++ b/src/Shell/AclShell.php
@@ -71,8 +71,7 @@ class AclShell extends Shell
 
         $class = Configure::read('Acl.classname');
         $className = App::classname('Acl.' . $class, 'Adapter');
-        if (
-            $class !== 'DbAcl' &&
+        if ($class !== 'DbAcl' &&
             !is_subclass_of($className, 'Acl\Adapter\DbAcl')
         ) {
             $out = "--------------------------------------------------\n";

--- a/tests/TestCase/AclExtrasTest.php
+++ b/tests/TestCase/AclExtrasTest.php
@@ -34,7 +34,7 @@ include ((dirname(__FILE__))) . DS . 'test_controllers.php';
 class AclExtrasShellTestCase extends TestCase
 {
 
-    public $fixtures = array('app.acos', 'app.aros', 'app.aros_acos');
+    public $fixtures = ['app.acos', 'app.aros', 'app.aros_acos'];
 
     /**
      * setUp
@@ -49,7 +49,7 @@ class AclExtrasShellTestCase extends TestCase
 
         $this->Task = $this->getMock(
             'AclExtras',
-            array('in', 'out', 'hr', 'createFile', 'error', 'err', 'clear', 'getControllerList')
+            ['in', 'out', 'hr', 'createFile', 'error', 'err', 'clear', 'getControllerList']
         );
     }
 
@@ -73,8 +73,8 @@ class AclExtrasShellTestCase extends TestCase
     {
         $this->markTestIncomplete('This test needs to be updated for cake3.');
         $this->Task->startup();
-        $this->Task->args = array('Aco');
-        $this->Task->Acl->Aco = $this->getMock('Aco', array('recover'));
+        $this->Task->args = ['Aco'];
+        $this->Task->Acl->Aco = $this->getMock('Aco', ['recover']);
         $this->Task->Acl->Aco->expects($this->once())
             ->method('recover')
             ->will($this->returnValue(true));
@@ -95,8 +95,8 @@ class AclExtrasShellTestCase extends TestCase
     {
         $this->markTestIncomplete('This test needs to be updated for cake3.');
         $this->Task->startup();
-        $this->Task->args = array('Aco');
-        $this->Task->Acl->Aco = $this->getMock('Aco', array('verify'));
+        $this->Task->args = ['Aco'];
+        $this->Task->Acl->Aco = $this->getMock('Aco', ['verify']);
         $this->Task->Acl->Aco->expects($this->once())
             ->method('verify')
             ->will($this->returnValue(true));
@@ -133,7 +133,7 @@ class AclExtrasShellTestCase extends TestCase
         $this->db->execute('DELETE FROM ' . $tableName);
         $this->Task->expects($this->any())
             ->method('getControllerList')
-            ->will($this->returnValue(array('CommentsController', 'PostsController', 'BigLongNamesController')));
+            ->will($this->returnValue(['CommentsController', 'PostsController', 'BigLongNamesController']));
 
         $this->Task->startup();
     }
@@ -185,10 +185,10 @@ class AclExtrasShellTestCase extends TestCase
         $Aco->cacheQueries = false;
 
         $result = $Aco->node('controllers/Comments');
-        $new = array(
+        $new = [
             'parent_id' => $result[0]['Aco']['id'],
             'alias' => 'some_method'
-        );
+        ];
         $Aco->create($new);
         $Aco->save();
         $children = $Aco->children($result[0]['Aco']['id']);

--- a/tests/TestCase/AclExtrasTest.php
+++ b/tests/TestCase/AclExtrasTest.php
@@ -24,8 +24,6 @@ use Cake\Controller\Controller;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
-
-
 //import test controller class names.
 include ((dirname(__FILE__))) . DS . 'test_controllers.php';
 
@@ -43,7 +41,8 @@ class AclExtrasShellTestCase extends TestCase
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         Configure::write('Acl.classname', 'DbAcl');
         Configure::write('Acl.database', 'test');
@@ -59,7 +58,8 @@ class AclExtrasShellTestCase extends TestCase
      *
      * @return void
      */
-    public function tearDown() {
+    public function tearDown()
+    {
         parent::tearDown();
         unset($this->Task);
     }
@@ -69,7 +69,8 @@ class AclExtrasShellTestCase extends TestCase
      *
      * @return void
      */
-    public function testRecover() {
+    public function testRecover()
+    {
         $this->markTestIncomplete('This test needs to be updated for cake3.');
         $this->Task->startup();
         $this->Task->args = array('Aco');
@@ -90,7 +91,8 @@ class AclExtrasShellTestCase extends TestCase
      *
      * @return void
      */
-    public function testVerify() {
+    public function testVerify()
+    {
         $this->markTestIncomplete('This test needs to be updated for cake3.');
         $this->Task->startup();
         $this->Task->args = array('Aco');
@@ -111,7 +113,8 @@ class AclExtrasShellTestCase extends TestCase
      *
      * @return void
      */
-    public function testStartup() {
+    public function testStartup()
+    {
         $this->markTestIncomplete('This test needs to be updated for cake3.');
         $this->assertEquals($this->Task->Acl, null);
         $this->Task->startup();
@@ -123,7 +126,8 @@ class AclExtrasShellTestCase extends TestCase
      *
      * @return void
      */
-    protected function _cleanAndSetup() {
+    protected function _cleanAndSetup()
+    {
         $this->markTestIncomplete('This test needs to be updated for cake3.');
         $tableName = $this->db->fullTableName('acos');
         $this->db->execute('DELETE FROM ' . $tableName);
@@ -139,7 +143,8 @@ class AclExtrasShellTestCase extends TestCase
      *
      * @return void
      */
-    public function testAcoUpdate() {
+    public function testAcoUpdate()
+    {
         $this->markTestIncomplete('This test needs to be updated for cake3.');
         $this->_cleanAndSetup();
         $this->Task->aco_update();
@@ -171,7 +176,8 @@ class AclExtrasShellTestCase extends TestCase
      *
      * @return void
      */
-    public function testAcoSyncRemoveMethods() {
+    public function testAcoSyncRemoveMethods()
+    {
         $this->_cleanAndSetup();
         $this->Task->aco_update();
 
@@ -201,7 +207,8 @@ class AclExtrasShellTestCase extends TestCase
      *
      * @return void
      */
-    public function testAcoUpdateAddingMethods() {
+    public function testAcoUpdateAddingMethods()
+    {
         $this->_cleanAndSetup();
         $this->Task->aco_update();
 
@@ -225,7 +232,8 @@ class AclExtrasShellTestCase extends TestCase
      *
      * @return void
      */
-    public function testAddingControllers() {
+    public function testAddingControllers()
+    {
         $this->_cleanAndSetup();
         $this->Task->aco_update();
 

--- a/tests/TestCase/test_controllers.php
+++ b/tests/TestCase/test_controllers.php
@@ -2,47 +2,58 @@
 
 use Cake\Controller\Controller;
 
-class CommentsController extends Controller {
+class CommentsController extends Controller
+{
 
-	public function add() {
-	}
+    public function add()
+    {
+    }
 
-	public function index() {
-	}
+    public function index()
+    {
+    }
 
-	public function delete() {
-	}
+    public function delete()
+    {
+    }
 
-	public function _secret_method() {
-	}
-
+    public function _secret_method()
+    {
+    }
 }
 
-class PostsController extends Controller {
+class PostsController extends Controller
+{
 
-	public function index() {
-	}
+    public function index()
+    {
+    }
 
-	public function add() {
-	}
+    public function add()
+    {
+    }
 
-	public function edit() {
-	}
-
+    public function edit()
+    {
+    }
 }
 
-class BigLongNamesController extends Controller {
+class BigLongNamesController extends Controller
+{
 
-	public function index() {
-	}
+    public function index()
+    {
+    }
 
-	public function view() {
-	}
+    public function view()
+    {
+    }
 
-	public function add() {
-	}
+    public function add()
+    {
+    }
 
-	public function delete() {
-	}
-
+    public function delete()
+    {
+    }
 }


### PR DESCRIPTION
use short array syntax and remove plugin-installer dependency.
The travis phpcs change is to avoid the migrations files to be checked and also this rules is pretty much in every other repos.