### PR TITLE
Setting the connection when using nodes

### DIFF
--- a/src/Model/Table/AclNodesTable.php
+++ b/src/Model/Table/AclNodesTable.php
@@ -110,7 +110,9 @@ class AclNodesTable extends Table
             $name = key($ref);
             list(, $alias) = pluginSplit($name);
 
-            $bindTable = TableRegistry::get($name);
+            $bindTable = TableRegistry::get($name, [
+                'connection' => Configure::read('Acl.database')
+            ]);
             $entityClass = $bindTable->entityClass();
 
             if ($entityClass) {

--- a/src/Model/Table/AclNodesTable.php
+++ b/src/Model/Table/AclNodesTable.php
@@ -110,9 +110,13 @@ class AclNodesTable extends Table
             $name = key($ref);
             list(, $alias) = pluginSplit($name);
 
-            $bindTable = TableRegistry::get($name, [
-                'connection' => Configure::read('Acl.database')
-            ]);
+            if (TableRegistry::exists($name)) {
+                $bindTable = TableRegistry::get($name);
+            } else {
+                $bindTable = TableRegistry::get($name, [
+                    'connection' => Configure::read('Acl.database')
+                ]);
+            }
             $entityClass = $bindTable->entityClass();
 
             if ($entityClass) {


### PR DESCRIPTION
Without a connection, when trying to get the Table, this would throw an exception if the users weren't in the default connection. This ensures that the connection set in the app config is respected when dealing with nodes.