### PR TITLE
ACO Sync should take into account custom app namespace

### DIFF
--- a/src/AclExtras.php
+++ b/src/AclExtras.php
@@ -369,7 +369,8 @@ class AclExtras
         $namespace = preg_replace('/\//', '\\', $namespace);
         $namespace = preg_replace('/\.php/', '', $namespace);
         if (!$pluginPath) {
-            $namespace = '\App\Controller\\' . $namespace;
+            $appNamespace = Configure::read('App.namespace');
+            $namespace = '\\' . $appNamespace . '\\Controller\\' . $namespace;
         } else {
             $pluginPath = preg_replace('/\//', '\\', $pluginPath);
             $namespace = '\\' . $pluginPath . 'Controller\\' . $namespace;


### PR DESCRIPTION
It is possible to customize the app namespace, the aco_sync command should use the configured namespace rather than assuming it is 'App'