### PR TITLE
fixing issue #47 - cake acl grant throws Unknown method "node"

### DIFF
--- a/src/Shell/AclShell.php
+++ b/src/Shell/AclShell.php
@@ -93,6 +93,7 @@ class AclShell extends Shell
 
             try {
                 \Cake\ORM\TableRegistry::get('Aros')->schema();
+                \Cake\ORM\TableRegistry::remove('Aros');
             } catch (\Cake\Database\Exception $e) {
                 $this->out(__d('cake_acl', 'Acl database tables not found. To create them, run:'));
                 $this->out();


### PR DESCRIPTION
fixing issue #47 - cake acl grant throws Unknown method "node" in ORM/Table; AclShell was forcing the TableRegistry to register a generic instance of Aros table