### PR TITLE
Remove verify()

### DIFF
--- a/src/AclExtras.php
+++ b/src/AclExtras.php
@@ -346,23 +346,6 @@ class AclExtras
     }
 
     /**
-     * Verify a Acl Tree
-     *
-     * @return void
-     */
-    public function verify()
-    {
-        $type = Inflector::camelize($this->args[0]);
-        $return = $this->Acl->{$type}->verify();
-        if ($return === true) {
-            $this->out(__('<success>Tree is valid and strong</success>'));
-        } else {
-            $this->err(print_r($return, true));
-            return false;
-        }
-    }
-
-    /**
      * Recover an Acl Tree
      *
      * @return void

--- a/src/Shell/AclExtrasShell.php
+++ b/src/Shell/AclExtrasShell.php
@@ -120,17 +120,6 @@ class AclExtrasShell extends Shell
                 'help' => __('Perform a full sync on the ACO table.' .
                     'Will create new ACOs or missing controllers and actions.' .
                     'Will also remove orphaned entries that no longer have a matching controller/action')
-            ])->addSubcommand('verify', [
-                'help' => __('Verify the tree structure of either your Aco or Aro Trees'),
-                'parser' => [
-                    'arguments' => [
-                        'type' => [
-                            'required' => true,
-                            'help' => __('The type of tree to verify'),
-                            'choices' => ['aco', 'aro']
-                        ]
-                    ]
-                ]
             ])->addSubcommand('recover', [
                 'help' => __('Recover a corrupted Tree'),
                 'parser' => [
@@ -143,18 +132,7 @@ class AclExtrasShell extends Shell
                     ]
                 ]
             ]);
-            return $parser;
-    }
-
-    /**
-     * Verify a Acl Tree
-     *
-     * @return void
-     */
-    public function verify()
-    {
-        $this->AclExtras->args = $this->args;
-        return $this->AclExtras->verify();
+        return $parser;
     }
 
     /**

--- a/tests/TestCase/AclExtrasTest.php
+++ b/tests/TestCase/AclExtrasTest.php
@@ -90,27 +90,6 @@ class AclExtrasTestCase extends TestCase
     }
 
     /**
-     * test verify
-     *
-     * @return void
-     */
-    public function testVerify()
-    {
-        $this->Task->startup();
-        $this->Task->args = ['Aco'];
-        $this->Task->Acl->Aco = $this->getMock('Aco', ['verify']);
-        $this->Task->Acl->Aco->expects($this->once())
-            ->method('verify')
-            ->will($this->returnValue(true));
-
-        $this->Task->expects($this->once())
-            ->method('out')
-            ->with($this->matchesRegularExpression('/valid/'));
-
-        $this->Task->verify();
-    }
-
-    /**
      * test startup
      *
      * @return void


### PR DESCRIPTION
This method is no longer offered by the core TreeBehavior, Acl plugin also does not implement these features.

Refs #52