### PR TITLE
Add ability to pass ID to node method

### DIFF
--- a/src/Model/Table/AclNodesTable.php
+++ b/src/Model/Table/AclNodesTable.php
@@ -53,6 +53,10 @@ class AclNodesTable extends Table
 
         if (empty($ref)) {
             return null;
+        } elseif (is_int($ref) || ctype_digit($ref)) {
+            $ref = [
+                'id' => $ref
+            ];
         } elseif (is_string($ref)) {
             $path = explode('/', $ref);
             $start = $path[0];

--- a/tests/TestCase/Model/Table/AclNodesTest.php
+++ b/tests/TestCase/Model/Table/AclNodesTest.php
@@ -240,6 +240,26 @@ class AclNodeTest extends TestCase
         $expected = [8, 7, 6, 1];
         $this->assertEquals($expected, $result);
 
+        $result = $Aco->node(8);
+        $result = $result->extract('id')->toArray();
+        $expected = [8, 7, 6, 1];
+        $this->assertEquals($expected, $result);
+
+        $result = $Aco->node(7);
+        $result = $result->extract('id')->toArray();
+        $expected = [7, 6, 1];
+        $this->assertEquals($expected, $result);
+
+        $result = $Aco->node(4);
+        $result = $result->extract('id')->toArray();
+        $expected = [4, 3, 2, 1];
+        $this->assertEquals($expected, $result);
+
+        $result = $Aco->node(3);
+        $result = $result->extract('id')->toArray();
+        $expected = [3, 2, 1];
+        $this->assertEquals($expected, $result);
+
         $this->assertFalse($Aco->node('Controller2/action3'));
 
         $this->assertFalse($Aco->node('Controller2/action3/record5'));


### PR DESCRIPTION
This will add the ability to pass an int to the `node` method, which will be used to search the corresponding ACO/ARO. This is for example useful for when you're creating permissions through the console, and you only want to define the ID of the ACO/ARO (when you got it from `aco view` or your database).