### PR TITLE
Update travis and composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_script:
   - composer self-update
 
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
-  - sh -c "if [ '$MINIMUMS' = '0' ]; then composer install --prefer-dist --no-interaction; fi"
+  - sh -c "if [ '$MINIMUMS' = '0' ]; then composer update --prefer-dist --no-interaction; fi"
   - sh -c "if [ '$MINIMUMS' = '1' ]; then composer update --prefer-dist --no-interaction --prefer-lowest; fi"
 
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,51 +1,58 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
 
 sudo: false
 
-env:
-  - DB=mysql db_class='Cake\Database\Driver\Mysql' db_dsn='mysql:host=0.0.0.0;dbname=cakephp_test' db_database='cakephp_test' db_login='travis' db_password=''
-  - DB=pgsql db_class='Cake\Database\Driver\Postgres' db_dsn='pgsql:host=127.0.0.1;dbname=cakephp_test' db_database="cakephp_test" db_login='postgres' db_password=''
-  - DB=sqlite db_class='Cake\Database\Driver\Sqlite' db_dsn='sqlite::memory:'
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
 
-services:
-  - memcached
+env:
+  matrix:
+    - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
+    - DB=sqlite db_dsn='sqlite:///:memory:'
+  global:
+    - RUN_TESTS=1
+    - MINIMUMS=0
 
 matrix:
-  allow_failures:
-    - php: hhvm-nightly
-    - php: 7.0
   fast_finish: true
-  include:
-    - php: 5.4
-      env: PHPCS=1
-    - php: hhvm-nightly
-      env: HHVM=1 DB=sqlite db_class='Cake\Database\Driver\Sqlite' db_dsn='sqlite::memory:'
-    - php: hhvm-nightly
-      env: HHVM=1 DB=mysql db_class='Cake\Database\Driver\Mysql' db_dsn='mysql:host=0.0.0.0;dbname=cakephp_test' db_database='cakephp_test' db_login='travis' db_password=''
 
+  include:
+    - php: 7.0
+      env: MINIMUMS=1
+
+    - php: 7.0
+      env: RUN_CS=1 RUN_TESTS=0
+
+    - php: 7.0
+      env: RUN_COVERAGE=1 RUN_TESTS=0 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
 
 before_script:
+  - phpenv config-rm xdebug.ini
+
   - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+
+  - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
+  - sh -c "if [ '$MINIMUMS' = '0' ]; then composer install --prefer-dist --no-interaction; fi"
+  - sh -c "if [ '$MINIMUMS' = '1' ]; then composer update --prefer-dist --no-interaction --prefer-lowest; fi"
+
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
-  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test2;'; fi"
-  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test3;'; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE SCHEMA test2;' -U postgres -d cakephp_test; fi"
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE SCHEMA test3;' -U postgres -d cakephp_test; fi"
-  - sh -c "if [ '$HHVM' != '1' ]; then echo 'extension = memcached.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
-  - phpenv rehash
-  - set +H
 
 script:
-  - sh -c "if [ '$PHPCS' != '1' ]; then phpunit; fi"
-  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p -n --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
+  - sh -c "if [ '$RUN_TESTS' = '1' ]; then vendor/bin/phpunit; fi"
+  - sh -c "if [ '$RUN_CS' = '1' ]; then vendor/bin/phpcs -n -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
+
+  - sh -c "if [ '$RUN_COVERAGE' = '1' ]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml || true; fi"
+  - sh -c "if [ '$RUN_COVERAGE' = '1' ]; then wget -O codecov.sh https://codecov.io/bash; fi"
+  - sh -c "if [ '$RUN_COVERAGE' = '1' ]; then bash codecov.sh; fi"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -26,7 +27,7 @@ matrix:
 
   include:
     - php: 7.0
-      env: MINIMUMS=1
+      env: MINIMUMS=1 RUN_TESTS=1
 
     - php: 7.0
       env: RUN_CS=1 RUN_TESTS=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
 
   include:
     - php: 7.0
-      env: MINIMUMS=1 RUN_TESTS=1
+      env: MINIMUMS=1 RUN_TESTS=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
 
     - php: 7.0
       env: RUN_CS=1 RUN_TESTS=0

--- a/README.md
+++ b/README.md
@@ -12,19 +12,16 @@ It is currently under development and should be considered experimental.
 
 ## Installing via composer
 
-You can install this plugin into your CakePHP application using
-[composer](http://getcomposer.org). For existing applications you can add the
-following to your `composer.json` file:
 
-```javascript
-"require": {
-	"cakephp/acl": "dev-master"
-}
+You can install this plugin into your CakePHP application using [composer](http://getcomposer.org).
+
+The recommended way to install composer packages is:
+
+```
+composer require cakephp/acl
 ```
 
-And run `php composer.phar update`
-
-In your `config\bootstrap.php`:
+Then in your `config\bootstrap.php`:
 ```php
 Plugin::load('Acl', ['bootstrap' => true]);
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # CakePHP Acl Plugin
 
-[![Build Status](https://api.travis-ci.org/cakephp/acl.png)](https://travis-ci.org/cakephp/acl)
-[![License](https://poser.pugx.org/cakephp/acl/license.svg)](https://packagist.org/packages/cakephp/acl)
+[![Build Status](https://img.shields.io/travis/cakephp/acl/master.svg?style=flat-square)](https://travis-ci.org/cakephp/acl)
+[![Coverage Status](https://img.shields.io/codecov/c/github/cakephp/acl.svg?style=flat-square)](https://codecov.io/github/cakephp/acl)
+[![License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.txt)
 
 A plugin for managing ACL in CakePHP applications.
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "dev-master",
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "dev-master",
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": ">= 4.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,12 @@
 		"irc": "irc://irc.freenode.org/cakephp",
 		"source": "https://github.com/cakephp/acl"
 	},
-	"minimum-stability": "dev",
 	"require": {
-		"cakephp/cakephp": "~3.0"
+		"cakephp/cakephp": "^3.0.1"
 	},
 	"require-dev": {
-		"cakephp/cakephp-codesniffer": "master-dev",
-		"phpunit/phpunit": "4.*"
+		"cakephp/cakephp-codesniffer": "dev-master",
+		"phpunit/phpunit": "~5.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,38 +1,41 @@
 {
-	"name": "cakephp/acl",
-	"description": "Acl Plugin for CakePHP 3.x framework",
-	"type": "cakephp-plugin",
-	"keywords": ["cakephp", "acl"],
-	"homepage": "http://cakephp.org",
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "CakePHP Community",
-			"homepage": "https://github.com/cakephp/acl/graphs/contributors"
-		}
-	],
-	"support": {
-		"issues": "https://github.com/cakephp/acl/issues",
-		"forum": "http://stackoverflow.com/tags/cakephp",
-		"irc": "irc://irc.freenode.org/cakephp",
-		"source": "https://github.com/cakephp/acl"
-	},
-	"require": {
-		"cakephp/cakephp": "^3.0.1"
-	},
-	"require-dev": {
-		"cakephp/cakephp-codesniffer": "dev-master",
-		"phpunit/phpunit": "~5.0"
-	},
-	"autoload": {
-		"psr-4": {
-			"Acl\\": "src"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"Acl\\Test\\": "tests",
-			"Cake\\Test\\": "vendor/cakephp/cakephp/tests"
-		}
-	}
+    "name": "cakephp/acl",
+    "description": "Acl Plugin for CakePHP 3.x framework",
+    "type": "cakephp-plugin",
+    "keywords": [
+        "cakephp",
+        "acl"
+    ],
+    "homepage": "http://cakephp.org",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "CakePHP Community",
+            "homepage": "https://github.com/cakephp/acl/graphs/contributors"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/cakephp/acl/issues",
+        "forum": "http://stackoverflow.com/tags/cakephp",
+        "irc": "irc://irc.freenode.org/cakephp",
+        "source": "https://github.com/cakephp/acl"
+    },
+    "require": {
+        "cakephp/cakephp": "^3.0.1"
+    },
+    "require-dev": {
+        "cakephp/cakephp-codesniffer": "dev-master",
+        "phpunit/phpunit": "^5.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Acl\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Acl\\Test\\": "tests",
+            "Cake\\Test\\": "vendor/cakephp/cakephp/tests"
+        }
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -49,4 +49,9 @@
 		<env name="db_password" value=""/>
 		-->
 	</php>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/TestCase/AclExtrasTest.php
+++ b/tests/TestCase/AclExtrasTest.php
@@ -286,18 +286,23 @@ class AclExtrasTestCase extends TestCase
             ->will($this->returnCallback(function ($plugin, $prefix) {
                 switch ($plugin) {
                     case 'TestPlugin':
-                        return ['PluginController.php'];
+                        $return = ['PluginController.php'];
+                        break;
                     case 'Nested/TestPluginTwo':
                         if ($prefix !== null) {
-                            return [];
+                            $return = [];
+                            break;
                         }
-                        return ['PluginTwoController.php'];
+                        $return = ['PluginTwoController.php'];
+                        break;
                     default:
                         if ($prefix !== null) {
-                            return ['PostsController.php', 'BigLongNamesController.php'];
+                            $return = ['PostsController.php', 'BigLongNamesController.php'];
+                            break;
                         }
-                        return ['CommentsController.php', 'PostsController.php', 'BigLongNamesController.php'];
+                        $return = ['CommentsController.php', 'PostsController.php', 'BigLongNamesController.php'];
                 }
+                return $return;
             }));
 
         $this->Task->startup();
@@ -345,10 +350,12 @@ class AclExtrasTestCase extends TestCase
 
                 switch ($plugin) {
                     case 'Nested/TestPluginTwo':
-                        return ['PluginTwoController.php'];
+                        $return = ['PluginTwoController.php'];
+                        break;
                     default:
-                        return ['CommentsController.php', 'PostsController.php', 'BigLongNamesController.php'];
+                        $return = ['CommentsController.php', 'PostsController.php', 'BigLongNamesController.php'];
                 }
+                return $return;
             }));
 
         $this->Task->startup();
@@ -371,10 +378,12 @@ class AclExtrasTestCase extends TestCase
 
                 switch ($plugin) {
                     case 'Nested/TestPluginTwo':
-                        return ['PluginTwoController.php'];
+                        $return = ['PluginTwoController.php'];
+                        break;
                     default:
-                        return ['CommentsController.php', 'PostsController.php', 'BigLongNamesController.php'];
+                        $return = ['CommentsController.php', 'PostsController.php', 'BigLongNamesController.php'];
                 }
+                return $return;
             }));
 
         $cleanTask->startup();


### PR DESCRIPTION
Bumps min cakephp version to 3.0.1 (first version with PHP7 support), and adds tests for PHP7, Codecov support and a minimum version test. 