### PR TITLE
Modification based on deprecated message of PHPUnit and modification based on the cakephp coding standerd

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="CakePHP Core">
     <file>./src</file>
+    <file>./tests</file>
     <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP"/>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<ruleset name="CakePHP Core">
+    <file>./src</file>
+    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP"/>
+</ruleset>

--- a/src/AclExtras.php
+++ b/src/AclExtras.php
@@ -170,6 +170,7 @@ class AclExtras
             $plugin = $params['plugin'];
             if (!Plugin::loaded($plugin)) {
                 $this->err(__d('cake_acl', "<error>Plugin {0} not found or not activated.</error>", [$plugin]));
+
                 return false;
             }
             $plugins = [$params['plugin']];
@@ -183,6 +184,7 @@ class AclExtras
             }
         }
         $this->out(__d('cake_acl', '<success>Aco Update Complete</success>'));
+
         return true;
     }
 
@@ -369,6 +371,7 @@ class AclExtras
         } else {
             $node = $node->first();
         }
+
         return $node;
     }
 
@@ -409,6 +412,7 @@ class AclExtras
                 $callbacks[] = $callable['callable'];
             }
         }
+
         return $callbacks;
     }
 
@@ -430,6 +434,7 @@ class AclExtras
         $methods = get_class_methods(new $namespace);
         if ($methods == null) {
             $this->err(__d('cake_acl', 'Unable to get methods for {0}', $className));
+
             return false;
         }
         $actions = array_diff($methods, $baseMethods);
@@ -452,6 +457,7 @@ class AclExtras
         if ($this->_clean) {
             $this->_cleaner($node->id, $actions);
         }
+
         return true;
     }
 

--- a/src/Adapter/IniAcl.php
+++ b/src/Adapter/IniAcl.php
@@ -165,6 +165,7 @@ class IniAcl implements AclInterface
                 }
             }
         }
+
         return false;
     }
 
@@ -178,6 +179,7 @@ class IniAcl implements AclInterface
     public function readConfigFile($filename)
     {
         $iniFile = new IniConfig(dirname($filename) . DS);
+
         return $iniFile->read(basename($filename));
     }
 
@@ -193,6 +195,7 @@ class IniAcl implements AclInterface
             $array[$key] = trim($value);
         }
         array_unshift($array, "");
+
         return $array;
     }
 }

--- a/src/Adapter/Utility/PhpAco.php
+++ b/src/Adapter/Utility/PhpAco.php
@@ -153,6 +153,7 @@ class PhpAco
         $aco = preg_replace('#/+#', '/', $aco);
         // make case insensitive
         $aco = ltrim(strtolower($aco), '/');
+
         return array_filter(array_map('trim', explode('/', $aco)));
     }
 

--- a/src/Adapter/Utility/PhpAro.php
+++ b/src/Adapter/Utility/PhpAro.php
@@ -157,6 +157,7 @@ class PhpAro
                 return $this->aliases[$mapped];
             }
         }
+
         return static::DEFAULT_ROLE;
     }
 

--- a/src/Auth/ActionsAuthorize.php
+++ b/src/Auth/ActionsAuthorize.php
@@ -37,6 +37,7 @@ class ActionsAuthorize extends BaseAuthorize
     {
         $Acl = $this->_registry->load('Acl');
         $user = [$this->_config['userModel'] => $user];
+
         return $Acl->check($user, $this->action($request));
     }
 }

--- a/src/Auth/CrudAuthorize.php
+++ b/src/Auth/CrudAuthorize.php
@@ -65,10 +65,12 @@ class CrudAuthorize extends BaseAuthorize
                 ),
                 E_USER_WARNING
             );
+
             return false;
         }
         $user = [$this->_config['userModel'] => $user];
         $Acl = $this->_registry->load('Acl');
+
         return $Acl->check(
             $user,
             $this->action($request, ':controller'),

--- a/src/Controller/Component/AclComponent.php
+++ b/src/Controller/Component/AclComponent.php
@@ -99,8 +99,10 @@ class AclComponent extends Component
             }
             $this->_Instance = $adapter;
             $this->_Instance->initialize($this);
+
             return;
         }
+
         return $this->_Instance;
     }
 

--- a/src/Model/Behavior/AclBehavior.php
+++ b/src/Model/Behavior/AclBehavior.php
@@ -103,12 +103,14 @@ class AclBehavior extends Behavior
             $type = $this->_typeMaps[$this->config('type')];
             if (is_array($type)) {
                 trigger_error(__d('cake_dev', 'AclBehavior is setup with more then one type, please specify type parameter for node()'), E_USER_WARNING);
+
                 return null;
             }
         }
         if (empty($ref)) {
             throw new Exception\Exception(__d('cake_dev', 'ref parameter must be a string or an Entity'));
         }
+
         return $this->_table->{$type}->node($ref);
     }
 

--- a/src/Model/Table/AclNodesTable.php
+++ b/src/Model/Table/AclNodesTable.php
@@ -183,6 +183,7 @@ class AclNodesTable extends Table
                 throw new Exception\Exception(__d('cake_dev', "AclNode::node() - Couldn't find {0} node identified by \"{1}\"", [$type, print_r($ref, true)]));
             }
         }
+
         return $query;
     }
 }

--- a/src/Model/Table/ArosTable.php
+++ b/src/Model/Table/ArosTable.php
@@ -45,6 +45,6 @@ class ArosTable extends AclNodesTable
             'foreignKey' => 'parent_id'
         ]);
 
-        $this->entityClass('Acl.Aro', 'Model/Entity');
+        $this->entityClass(App::className('Acl.Aro', 'Model/Entity'));
     }
 }

--- a/src/Model/Table/PermissionsTable.php
+++ b/src/Model/Table/PermissionsTable.php
@@ -75,6 +75,7 @@ class PermissionsTable extends AclNodesTable
                 ),
                 E_USER_WARNING
             );
+
             return false;
         }
 
@@ -89,11 +90,13 @@ class PermissionsTable extends AclNodesTable
                 ),
                 E_USER_WARNING
             );
+
             return false;
         }
 
         if ($action !== '*' && !in_array('_' . $action, $permKeys)) {
             trigger_error(__d('cake_dev', "ACO permissions key {0} does not exist in {1}", $action, 'DbAcl::check()'), E_USER_NOTICE);
+
             return false;
         }
 
@@ -145,6 +148,7 @@ class PermissionsTable extends AclNodesTable
                 }
             }
         }
+
         return false;
     }
 
@@ -167,6 +171,7 @@ class PermissionsTable extends AclNodesTable
 
         if (!$perms) {
             trigger_error(__d('cake_dev', '{0} - Invalid node', ['DbAcl::allow()']), E_USER_WARNING);
+
             return false;
         }
         if (isset($perms[0])) {
@@ -203,6 +208,7 @@ class PermissionsTable extends AclNodesTable
         }
         $entityClass = $this->entityClass();
         $entity = new $entityClass($save);
+
         return ($this->save($entity) !== false);
     }
 
@@ -240,6 +246,7 @@ class PermissionsTable extends AclNodesTable
                 ])->hydrate(false)->toArray()
             ],
         ];
+
         return $result;
     }
 
@@ -257,6 +264,7 @@ class PermissionsTable extends AclNodesTable
                 $newKeys[] = $key;
             }
         }
+
         return $newKeys;
     }
 }

--- a/src/Shell/AclExtrasShell.php
+++ b/src/Shell/AclExtrasShell.php
@@ -131,6 +131,7 @@ class AclExtrasShell extends Shell
                     ]
                 ]
             ]);
+
             return $parser;
     }
 

--- a/src/Shell/AclShell.php
+++ b/src/Shell/AclShell.php
@@ -94,6 +94,7 @@ class AclShell extends Shell
                 $this->out(__d('cake_acl', 'Your database configuration was not found. Take a moment to create one.'));
                 $this->args = null;
                 $this->DbConfig->execute();
+
                 return;
             }
 
@@ -106,6 +107,7 @@ class AclShell extends Shell
                 $this->out('  bin/cake Migrations.migrations migrate -p Acl');
                 $this->out();
                 $this->_stop();
+
                 return;
             }
 
@@ -524,6 +526,7 @@ class AclShell extends Shell
                 "To add a node at the root level, enter 'root' or '/' as the <parent> parameter."
             ]
         );
+
         return $parser;
     }
 
@@ -545,6 +548,7 @@ class AclShell extends Shell
         if (empty($possibility)) {
             $this->error(__d('cake_acl', '{0} not found', [$this->args[1]]), __d('cake_acl', 'No tree returned.'));
         }
+
         return $possibility;
     }
 
@@ -563,6 +567,7 @@ class AclShell extends Shell
                 'foreign_key' => $matches[2],
             ];
         }
+
         return $identifier;
     }
 
@@ -582,8 +587,10 @@ class AclShell extends Shell
                 $identifier = var_export($identifier, true);
             }
             $this->error(__d('cake_acl', 'Could not find node using reference "{0}"', [$identifier]));
+
             return null;
         }
+
         return $node->first()->id;
     }
 
@@ -609,6 +616,7 @@ class AclShell extends Shell
         if (isset($this->args[2]) && !in_array($this->args[2], ['', 'all'])) {
             $action = $this->args[2];
         }
+
         return compact('aro', 'aco', 'action', 'aroName', 'acoName');
     }
 
@@ -629,6 +637,7 @@ class AclShell extends Shell
         $vars['data_name'] = $type;
         $vars['table_name'] = $type . 's';
         $vars['class'] = $class;
+
         return $vars;
     }
 }

--- a/tests/TestCase/AclExtrasTest.php
+++ b/tests/TestCase/AclExtrasTest.php
@@ -50,10 +50,9 @@ class AclExtrasTestCase extends TestCase
         Configure::write('Acl.classname', 'DbAcl');
         Configure::write('Acl.database', 'test');
 
-        $this->Task = $this->getMock(
-            'Acl\AclExtras',
-            ['in', 'out', 'hr', 'createFile', 'error', 'err', 'clear', 'getControllerList']
-        );
+        $this->Task = $this->getMockBuilder('Acl\AclExtras')
+            ->setMethods(['in', 'out', 'hr', 'createFile', 'error', 'err', 'clear', 'getControllerList'])
+            ->getMock();
     }
 
     /**
@@ -76,7 +75,9 @@ class AclExtrasTestCase extends TestCase
     {
         $this->Task->startup();
         $this->Task->args = ['Aco'];
-        $this->Task->Acl->Aco = $this->getMock('Aco', ['recover']);
+        $this->Task->Acl->Aco = $this->getMockBuilder('Aco')
+            ->setMethods(['recover'])
+            ->getMock();
         $this->Task->Acl->Aco->expects($this->once())
             ->method('recover')
             ->will($this->returnValue(true));
@@ -364,10 +365,9 @@ class AclExtrasTestCase extends TestCase
         $Aco = $this->Task->Acl->Aco;
         $originalNode = $Aco->node('controllers/Nested\TestPluginTwo/PluginTwo')->first();
 
-        $cleanTask = $this->getMock(
-            'Acl\AclExtras',
-            ['in', 'out', 'hr', 'createFile', 'error', 'err', 'clear', 'getControllerList']
-        );
+        $cleanTask = $this->getMockBuilder('Acl\AclExtras')
+            ->setMethods(['in', 'out', 'hr', 'createFile', 'error', 'err', 'clear', 'getControllerList'])
+            ->getMock();
 
         $cleanTask->expects($this->atLeast(2))
             ->method('getControllerList')

--- a/tests/TestCase/AclExtrasTest.php
+++ b/tests/TestCase/AclExtrasTest.php
@@ -303,6 +303,7 @@ class AclExtrasTestCase extends TestCase
                         }
                         $return = ['CommentsController.php', 'PostsController.php', 'BigLongNamesController.php'];
                 }
+
                 return $return;
             }));
 
@@ -356,6 +357,7 @@ class AclExtrasTestCase extends TestCase
                     default:
                         $return = ['CommentsController.php', 'PostsController.php', 'BigLongNamesController.php'];
                 }
+
                 return $return;
             }));
 
@@ -383,6 +385,7 @@ class AclExtrasTestCase extends TestCase
                     default:
                         $return = ['CommentsController.php', 'PostsController.php', 'BigLongNamesController.php'];
                 }
+
                 return $return;
             }));
 

--- a/tests/TestCase/AclShellTest.php
+++ b/tests/TestCase/AclShellTest.php
@@ -17,12 +17,13 @@ class AclShellTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->io = $this->getMock('Cake\Console\ConsoleIo', [], [], '', false);
-        $this->Shell = $this->getMock(
-            'Acl\Shell\AclShell',
-            ['in', 'out', 'hr', 'err', '_stop'],
-            [$this->io]
-        );
+        $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->Shell = $this->getMockBuilder('Acl\Shell\AclShell')
+            ->setMethods(['in', 'out', 'hr', 'err', '_stop'])
+            ->setConstructorArgs([$this->io])
+            ->getMock();
         Configure::write('Acl.classname', 'DbAcl');
         Configure::write('Acl.database', 'test');
         $this->Acos = TableRegistry::get('Acl\Model\Table\AcosTable');

--- a/tests/TestCase/Adapter/CacheDbAclTest.php
+++ b/tests/TestCase/Adapter/CacheDbAclTest.php
@@ -125,7 +125,9 @@ class CacheDbAclTest extends TestCase
      */
     public function testCaching()
     {
-        $this->CachedDb->Permission = $this->getMock('Acl\\Model\\Table\\PermissionsTable');
+        $this->CachedDb->Permission = $this
+            ->getMockBuilder('Acl\Model\Table\PermissionsTable')
+            ->getMock();
 
         $this->CachedDb->Permission
             ->expects($this->once())
@@ -144,7 +146,9 @@ class CacheDbAclTest extends TestCase
      */
     public function testCacheFalse()
     {
-        $this->CachedDb->Permission = $this->getMock('Acl\\Model\\Table\\PermissionsTable');
+        $this->CachedDb->Permission = $this
+            ->getMockBuilder('Acl\Model\Table\PermissionsTable')
+            ->getMock();
 
         $this->CachedDb->Permission
             ->expects($this->once())
@@ -163,7 +167,9 @@ class CacheDbAclTest extends TestCase
      */
     public function testCacheCleared()
     {
-        $this->CachedDb->Permission = $this->getMock('Acl\\Model\\Table\\PermissionsTable');
+        $this->CachedDb->Permission = $this
+            ->getMockBuilder('Acl\Model\Table\PermissionsTable')
+            ->getMock();
 
         $this->CachedDb->Permission
             ->expects($this->exactly(2))

--- a/tests/TestCase/Auth/ActionsAuthorizeTest.php
+++ b/tests/TestCase/Auth/ActionsAuthorizeTest.php
@@ -32,9 +32,14 @@ class ActionsAuthorizeTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $this->controller = $this->getMock('Cake\Controller\Controller', [], [], '', false);
-        $this->Acl = $this->getMock('Acl\Controller\Component\AclComponent', [], [], '', false);
-        $this->Collection = $this->getMock('Cake\Controller\ComponentRegistry');
+        $this->controller = $this->getMockBuilder('Cake\Controller\Controller')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->Acl = $this->getMockBuilder('Acl\Controller\Component\AclComponent')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->Collection = $this->getMockBuilder('Cake\Controller\ComponentRegistry')
+            ->getMock();
 
         $this->auth = new ActionsAuthorize($this->Collection);
         $this->auth->config('actionPath', '/controllers');

--- a/tests/TestCase/Auth/CrudAuthorizeTest.php
+++ b/tests/TestCase/Auth/CrudAuthorizeTest.php
@@ -37,8 +37,11 @@ class CrudAuthorizeTest extends TestCase
         Configure::write('Routing.prefixes', []);
         Router::reload();
 
-        $this->Acl = $this->getMock('Acl\Controller\Component\AclComponent', [], [], '', false);
-        $this->Components = $this->getMock('Cake\Controller\ComponentRegistry');
+        $this->Acl = $this->getMockBuilder('Acl\Controller\Component\AclComponent')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->Components = $this->getMockBuilder('Cake\Controller\ComponentRegistry')
+            ->getMock();
 
         $this->auth = new CrudAuthorize($this->Components);
     }

--- a/tests/TestCase/Controller/Component/AclComponentTest.php
+++ b/tests/TestCase/Controller/Component/AclComponentTest.php
@@ -34,7 +34,9 @@ class AclComponentTest extends TestCase
     {
         parent::setUp();
         if (!class_exists('MockAclImplementation', false)) {
-            $this->getMock('Acl\AclInterface', [], [], 'MockAclImplementation');
+            $this->getMockBuilder('Acl\AclInterface')
+                ->setMockClassName('MockAclImplementation')
+                ->getMock();
         }
         Configure::write('Acl.classname', '\MockAclImplementation');
         $Collection = new ComponentRegistry();
@@ -73,7 +75,7 @@ class AclComponentTest extends TestCase
      */
     public function testAdapter()
     {
-        $Adapter = $this->getMock('Acl\AclInterface');
+        $Adapter = $this->getMockBuilder('Acl\AclInterface')->getMock();
         $Adapter->expects($this->once())->method('initialize')->with($this->Acl);
 
         $this->assertNull($this->Acl->adapter($Adapter));

--- a/tests/TestCase/Model/Behavior/AclBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/AclBehaviorTest.php
@@ -79,6 +79,7 @@ class AclPerson extends Entity
         if (!$motherId) {
             return null;
         }
+
         return ['AclPeople' => ['id' => $motherId]];
     }
 }


### PR DESCRIPTION
Modification based on deprecated message of PHPUnit (Fixed App::className: b90e7ab)
Modification based on the cakephp coding standerd 	(Fixed for phpcs: 74436f0)

Fixed $this->entityClass()  argument mistake.