### PR TITLE
Skip abstract (and other uninstantiable) controllers to resolve #110

### DIFF
--- a/src/AclExtras.php
+++ b/src/AclExtras.php
@@ -305,7 +305,13 @@ class AclExtras
         foreach ($controllers as $controller) {
             $tmp = explode('/', $controller);
             $controllerName = str_replace('Controller.php', '', array_pop($tmp));
+            // Always skip the App controller
             if ($controllerName == 'App') {
+                continue;
+            }
+            // Skip anything that is not a concrete controller
+            $namespace = $this->_getNamespace($controller, $pluginPath, $prefix);
+            if (!(new \ReflectionClass($namespace))->isInstantiable()) {
                 continue;
             }
             $controllersNames[] = $controllerName;

--- a/tests/TestCase/AclExtrasTest.php
+++ b/tests/TestCase/AclExtrasTest.php
@@ -120,7 +120,13 @@ class AclExtrasTestCase extends TestCase
             ->with(null)
             ->will($this->returnCallback(function ($plugin, $prefix) {
                 if ($prefix === null) {
-                    return ['CommentsController.php', 'PostsController.php', 'BigLongNamesController.php'];
+                    return [
+                        'CommentsController.php',
+                        'PostsController.php',
+                        'BigLongNamesController.php',
+                        'AbstractController.php',
+                        'ConcreteController.php',
+                    ];
                 } else {
                     return ['PostsController.php', 'BigLongNamesController.php'];
                 }

--- a/tests/TestCase/test_controllers.php
+++ b/tests/TestCase/test_controllers.php
@@ -58,3 +58,43 @@ class BigLongNamesController extends Controller
     {
     }
 }
+
+abstract class AbstractController extends Controller
+{
+
+    public function index()
+    {
+    }
+
+    public function view()
+    {
+    }
+
+    public function add()
+    {
+    }
+
+    public function delete()
+    {
+    }
+}
+
+class ConcreteController extends AbstractController
+{
+
+    public function index()
+    {
+    }
+
+    public function view()
+    {
+    }
+
+    public function add()
+    {
+    }
+
+    public function delete()
+    {
+    }
+}


### PR DESCRIPTION
This is a simple fix, using reflection in `AclExtras->_updateControllers` to confirm that a controller is instantiable before it is added to the list of ones that will be instantiated in `_checkMethods`.

Travis-CI shows failures, because every job that involves MySQL [fails to install it 5.5](https://travis-ci.org/mikeu/acl/jobs/181145416#L278-L280). The last successful push to the Acl repo (e5010b4) was on 25 November. Two days ago on 2 December, the OS details for the build image were changed from Ubuntu 14.04.4 to 14.04.5 (compare [this job log](https://travis-ci.org/cakephp/acl/jobs/178965268#L13-L19) to [this one](https://travis-ci.org/mikeu/acl/jobs/181145416#L13-L19)), which seems to have broken support for MySQL 5.5. 

Changing the `.travis.yml` file to explicitly install `mysql-server-5.6` instead of the more generic `mysql-server` causes all jobs to succeed again (see https://travis-ci.org/mikeu/acl/builds/181151794). This PR doesn't include any changes to the travis config though, since dropping support for a MySQL version is well beyond the scope of the bug it addresses.