### PR TITLE
use get_class_methods() with string instead of instance

### DIFF
--- a/src/AclExtras.php
+++ b/src/AclExtras.php
@@ -440,7 +440,7 @@ class AclExtras
         $excludes = $this->_getCallbacks($className, $pluginPath, $prefixPath);
         $baseMethods = get_class_methods(new Controller);
         $namespace = $this->_getNamespace($className, $pluginPath, $prefixPath);
-        $methods = get_class_methods(new $namespace);
+        $methods = get_class_methods($namespace);
         if ($methods == null) {
             $this->err(__d('cake_acl', 'Unable to get methods for {0}', $className));
 


### PR DESCRIPTION
Using `_checkMethods()` when calling `acoUpdate()` from a controller can cause Exception when instantiating controllers.

In my case i use https://github.com/croogo/croogo. It implements an interface to update ACL.

```php
// In a controller
$AclExtras = new AclExtras();
$AclExtras->startup($this);
$AclExtras->acoUpdate();
```

## With

```php
// $namespace = "App\Controller\UsersController"
$methods = get_class_methods(new $namespace);
```

I have an exception

```
object(RuntimeException) {
	[protected] message => 'You cannot configure "Croogo/Nodes.Nodes", it has already been constructed.'
	[protected] code => (int) 0
	[protected] file => '/var/www/vendor/cakephp/cakephp/src/ORM/Locator/TableLocator.php'
	[protected] line => (int) 76
}
```

## But with

```php
// $namespace = "App\Controller\UsersController"
$methods = get_class_methods($namespace);
```
It works all the time (tests are always OK).
