### PR TITLE
3.7 deprecations

### DIFF
--- a/tests/TestCase/AclExtrasTest.php
+++ b/tests/TestCase/AclExtrasTest.php
@@ -37,7 +37,11 @@ include dirname(__FILE__) . DS . 'test_plugin_admin_controllers.php';
 class AclExtrasTestCase extends TestCase
 {
 
-    public $fixtures = ['app.acos', 'app.aros', 'app.aros_acos'];
+    public $fixtures = [
+        'app.Acos',
+        'app.Aros',
+        'app.ArosAcos',
+    ];
 
     /**
      * setUp

--- a/tests/TestCase/AclExtrasTest.php
+++ b/tests/TestCase/AclExtrasTest.php
@@ -338,10 +338,12 @@ class AclExtrasTestCase extends TestCase
      */
     public function testUpdateWithPlugins()
     {
-        Plugin::unload();
-        Plugin::load('TestPlugin', ['routes' => true]);
-        Plugin::load('Nested/TestPluginTwo');
-        Plugin::routes();
+        $this->deprecated(function () {
+            Plugin::unload();
+            Plugin::load('TestPlugin', ['routes' => true]);
+            Plugin::load('Nested/TestPluginTwo');
+            Plugin::routes();
+        });
         $this->_clean();
 
         $this->Task->expects($this->atLeast(3))
@@ -401,8 +403,10 @@ class AclExtrasTestCase extends TestCase
      */
     public function testSyncWithNestedPlugin()
     {
-        Plugin::unload();
-        Plugin::load('Nested/TestPluginTwo');
+        $this->deprecated(function () {
+            Plugin::unload();
+            Plugin::load('Nested/TestPluginTwo');
+        });
         $this->_clean();
 
         $this->Task->expects($this->atLeast(2))

--- a/tests/TestCase/AclShellTest.php
+++ b/tests/TestCase/AclShellTest.php
@@ -11,7 +11,9 @@ use Cake\TestSuite\TestCase;
 class AclShellTest extends TestCase
 {
     public $fixtures = [
-        'app.acos', 'app.aros', 'app.aros_acos',
+        'app.Acos',
+        'app.Aros',
+        'app.ArosAcos',
     ];
 
     public function setUp()

--- a/tests/TestCase/Adapter/CacheDbAclTest.php
+++ b/tests/TestCase/Adapter/CacheDbAclTest.php
@@ -66,7 +66,9 @@ class CacheDbAclTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['core.users'];
+    public $fixtures = [
+        'core.Users',
+    ];
 
     /**
      * setUp method

--- a/tests/TestCase/Adapter/DbAclTest.php
+++ b/tests/TestCase/Adapter/DbAclTest.php
@@ -146,7 +146,11 @@ class DbAclTest extends TestCase
      *
      * @var array
      */
-    public $fixtures = ['app.aro_twos', 'app.aco_twos', 'app.aros_aco_twos'];
+    public $fixtures = [
+        'app.AcoTwos',
+        'app.AroTwos',
+        'app.ArosAcoTwos',
+    ];
 
     /**
      * setUp method

--- a/tests/TestCase/Model/Behavior/AclBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/AclBehaviorTest.php
@@ -178,8 +178,12 @@ class AclBehaviorTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'app.people', 'core.users', 'core.posts',
-        'app.acos', 'app.aros', 'app.aros_acos',
+        'app.Acos',
+        'app.Aros',
+        'app.ArosAcos',
+        'app.People',
+        'core.Posts',
+        'core.Users',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/AclNodesTest.php
+++ b/tests/TestCase/Model/Table/AclNodesTest.php
@@ -177,8 +177,11 @@ class AclNodeTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'app.aros', 'app.acos', 'app.aros_acos',
-        'app.aco_actions', 'core.auth_users',
+        'app.AcoActions',
+        'app.Acos',
+        'app.Aros',
+        'app.ArosAcos',
+        'core.AuthUsers',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/AclNodesTest.php
+++ b/tests/TestCase/Model/Table/AclNodesTest.php
@@ -362,7 +362,9 @@ class AclNodeTest extends TestCase
      */
     public function testNodeActionAuthorize()
     {
-        Plugin::load('TestPlugin', ['autoload' => true]);
+        $this->deprecated(function () {
+            Plugin::load('TestPlugin', ['autoload' => true]);
+        });
 
         $Aro = TableRegistry::getTableLocator()->get('DbAroTest');
         $Aro->setEntityClass(App::className('TestPlugin.TestPluginAuthUser', 'Model/Entity'));
@@ -377,6 +379,9 @@ class AclNodeTest extends TestCase
         $result = $node->extract('id')->toArray();
         $expected = $aro->id;
         $this->assertEquals($expected, $result[0]);
-        Plugin::unload('TestPlugin');
+
+        $this->deprecated(function () {
+            Plugin::unload('TestPlugin');
+        });
     }
 }


### PR DESCRIPTION
I've used same method as in [cakephp/bake](https://github.com/cakephp/bake/pull/477/files#diff-9cd97b9850ca4bc60c9b728a10be785aL73) to suppress warnings