### PR TITLE
Add $Shell and $controller properties to AclExtras

### DIFF
--- a/src/AclExtras.php
+++ b/src/AclExtras.php
@@ -87,6 +87,9 @@ class AclExtras
      */
     protected $foundACOs = [];
 
+    /** @var \Cake\Controller\Controller */
+    protected $controller;
+
     /**
      * Start up And load Acl Component / Aco model
      *
@@ -585,5 +588,15 @@ class AclExtras
     public function getPluginPrefixes()
     {
         return $this->pluginPrefixes;
+    }
+
+    /**
+     * Get the attached controller.
+     *
+     * @return \Cake\Controller\Controller
+     */
+    public function getController()
+    {
+        return $this->controller;
     }
 }

--- a/src/AclExtras.php
+++ b/src/AclExtras.php
@@ -13,6 +13,7 @@
 namespace Acl;
 
 use Acl\Controller\Component\AclComponent;
+use Cake\Console\Shell;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
 use Cake\Core\App;
@@ -89,6 +90,9 @@ class AclExtras
 
     /** @var \Cake\Controller\Controller */
     protected $controller;
+
+    /** @var \Cake\Console\Shell */
+    protected $Shell;
 
     /**
      * Start up And load Acl Component / Aco model
@@ -598,5 +602,26 @@ class AclExtras
     public function getController()
     {
         return $this->controller;
+    }
+
+    /**
+     * Get the attached shell.
+     *
+     * @return \Cake\Console\Shell
+     */
+    public function getShell()
+    {
+        return $this->Shell;
+    }
+
+    /**
+     * Attach a shell for output.
+     *
+     * @param \Cake\Console\Shell $shell Shell to attach
+     * @return void
+     */
+    public function setShell(Shell $shell)
+    {
+        $this->Shell = $shell;
     }
 }


### PR DESCRIPTION
One of our CI tools (I think it was Scrutinizer) recently complained about the fact that we were accessing `AclExtras->Shell` directly, without such a property existing on the class itself.  This PR adds it, and `$controller`, as protected properties, with necessary getters and setters in place as well.

I realise this probably breaks BC... if `$Shell` and `$controller` need to be `public` instead I'd be happy to make the necessary adjustments.