### PR TITLE
Fix component's constructor error message

### DIFF
--- a/src/Controller/Component/AclComponent.php
+++ b/src/Controller/Component/AclComponent.php
@@ -70,7 +70,7 @@ class AclComponent extends Component
         if (!class_exists($className)) {
             $className = App::className('Acl.' . $name, 'Adapter');
             if (!$className) {
-                throw new Exception(sprintf('Could not find {0}.', [$name]));
+                throw new Exception(sprintf('Could not find %s.', $name));
             }
         }
         $this->adapter($className);


### PR DESCRIPTION
The text of the exception in the component's constructor is incorrect because of the incorrect using of `sprintf`.