### PR TITLE
Update ACL Plugin for CakePHP 4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /composer.lock
 /vendor
 /phpunit.xml
+.phpunit.result.cache
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
 
@@ -20,17 +17,9 @@ env:
     - DB=sqlite db_dsn='sqlite:///:memory:' quoteIdentifiers=false
   global:
     - DEFAULT=1
-    - MINIMUMS=0
 
 matrix:
   fast_finish: true
-
-  include:
-    - php: 7.0
-      env: MINIMUMS=1 DEFAULT=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
-
-    - php: 7.0
-      env: PHPCS=1 DEFAULT=0
 
 before_install:
   - if [[ $TRAVIS_PHP_VERSION != 7.3 ]]; then phpenv config-rm xdebug.ini; fi
@@ -45,14 +34,11 @@ before_install:
   - set +H
 
 before_script:
-  - sh -c "if [ '$MINIMUMS' = '0' ]; then composer update --prefer-dist --no-interaction; fi"
-  - sh -c "if [ '$MINIMUMS' = '1' ]; then composer update --prefer-dist --no-interaction --prefer-lowest; fi"
+  - sh -c "composer update --prefer-dist --no-interaction --prefer-lowest"
 
 script:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.* ]]; then export CODECOVERAGE=1 ; phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.* ]]; then vendor/bin/phpunit; fi
-
-  - if [[ $PHPCS = 1 ]]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi
 
 after_success:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.* ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 php:
   - 7.2
   - 7.3
-  - 7.4snapshot'
+  - '7.4snapshot'
 
 dist: trusty
 
@@ -18,6 +18,7 @@ env:
     - DB=sqlite db_dsn='sqlite:///:memory:' quoteIdentifiers=false
   global:
     - DEFAULT=1
+    - MINIMUMS=0
 
 matrix:
   fast_finish: true
@@ -39,11 +40,14 @@ before_install:
   - set +H
 
 before_script:
-  - sh -c "composer update --prefer-dist --no-interaction --prefer-lowest"
+  - sh -c "if [ '$MINIMUMS' = '0' ]; then composer update --prefer-dist --no-interaction; fi"
+  - sh -c "if [ '$MINIMUMS' = '1' ]; then composer update --prefer-dist --no-interaction --prefer-lowest; fi"
 
 script:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.* ]]; then export CODECOVERAGE=1 ; phpdbg -qrr vendor/bin/phpunit --coverage-clover=clover.xml; fi
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.* ]]; then vendor/bin/phpunit; fi
+
+  - if [[ $PHPCS = 1 ]]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi
 
 after_success:
   - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.* ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4snapshot'
 
 dist: trusty
 
@@ -21,8 +22,12 @@ env:
 matrix:
   fast_finish: true
 
+  include:
+    - php: 7.2
+      env: MINIMUMS=1 DEFAULT=1 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION != 7.3 ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION != "7.4snapshot" ]]; then phpenv config-rm xdebug.ini; fi
 
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "dev-next",
-        "phpunit/phpunit": "^5.7.14|^6.0"
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "cakephp/acl",
-    "description": "Acl Plugin for CakePHP 3.x framework",
+    "description": "Acl Plugin for CakePHP 4.x framework",
     "type": "cakephp-plugin",
     "keywords": [
         "cakephp",
@@ -21,11 +21,11 @@
         "source": "https://github.com/cakephp/acl"
     },
     "require": {
-        "cakephp/cakephp": "^3.6.0",
+        "cakephp/cakephp": "4.x-dev as 4.0.0",
         "cakephp/plugin-installer": "*"
     },
     "require-dev": {
-        "cakephp/cakephp-codesniffer": "^3.0",
+        "cakephp/cakephp-codesniffer": "dev-next",
         "phpunit/phpunit": "^5.7.14|^6.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,6 @@
             "Acl\\Test\\": "tests",
             "Cake\\Test\\": "vendor/cakephp/cakephp/tests"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,26 +27,16 @@
 	<php>
 		<!-- SQLite
 		<env name="db_class" value="Cake\Database\Driver\Sqlite"/>
-		<env name="db_dsn" value="sqlite::memory:"/>
+		<env name="db_dsn" value="sqlite:///:memory:"/>
 		-->
 		<!-- Postgres
-		<env name="db_class" value="Cake\Database\Driver\Postgres"/>
-		<env name="db_database" value="cake_test"/>
-		<env name="db_login" value=""/>
-		<env name="db_password" value=""/>
+		<env name="db_dsn" value="postgres://localhost/cake_test?timezone=UTC"/>
 		-->
 		<!-- Mysql
-		<env name="db_class" value="Cake\Database\Driver\Mysql"/>
-		<env name="db_dsn" value="mysql:host=localhost;dbname=cake_test"/>
-		<env name="db_database" value=""/>
-		<env name="db_login" value=""/>
-		<env name="db_password" value=""/>
+		<env name="db_dsn" value="mysql://localhost/cake_test?timezone=UTC"/>
 		-->
 		<!-- SQL Server
-		<env name="db_class" value="Cake\Database\Driver\Sqlserver"/>
-		<env name="db_dsn" value="sqlsrv:Server=localhost;Database=cake_test;MultipleActiveResultSets=false"/>
-		<env name="db_login" value=""/>
-		<env name="db_password" value=""/>
+		<env name="db_dsn" value="sqlserver://localhost/cake_test?timezone=UTC"/>
 		-->
 	</php>
     <filter>

--- a/src/AclExtras.php
+++ b/src/AclExtras.php
@@ -348,7 +348,7 @@ class AclExtras
     public function getControllerList($plugin = null, $prefix = null)
     {
         if (!$plugin) {
-            $path = App::path('Controller' . (empty($prefix) ? '' : DS . Inflector::camelize($prefix)));
+            $path = App::classPath('Controller' . (empty($prefix) ? '' : DS . Inflector::camelize($prefix)));
             $dir = new Folder($path[0]);
             $controllers = $dir->find('.*Controller\.php');
         } else {

--- a/src/AclExtras.php
+++ b/src/AclExtras.php
@@ -220,9 +220,9 @@ class AclExtras
             $pathNode = $this->_checkNode($path, $prefix, $root->id);
             $this->foundACOs[$root->id][] = $prefix;
             if (isset($this->foundACOs[$pathNode->id])) {
-                $this->foundACOs[$pathNode->id] += $this->_updateControllers($pathNode, $controllers, null, $prefix);
+                $this->foundACOs[$pathNode->id] += $this->_updateControllers($pathNode, $controllers, '', $prefix);
             } else {
-                $this->foundACOs[$pathNode->id] = $this->_updateControllers($pathNode, $controllers, null, $prefix);
+                $this->foundACOs[$pathNode->id] = $this->_updateControllers($pathNode, $controllers, '', $prefix);
             }
         }
     }
@@ -233,7 +233,7 @@ class AclExtras
      * @param string $plugin The name of the plugin to alias
      * @return string
      */
-    protected function _pluginAlias($plugin)
+    protected function _pluginAlias(string $plugin) :string
     {
         return preg_replace('/\//', '\\', Inflector::camelize($plugin));
     }
@@ -303,7 +303,7 @@ class AclExtras
      * @param string $prefix Name of the prefix you are making controllers for.
      * @return array
      */
-    protected function _updateControllers($root, $controllers, $plugin = null, $prefix = null)
+    protected function _updateControllers($root, array $controllers, string $plugin = '', string $prefix = '')
     {
         $pluginPath = $this->_pluginAlias($plugin);
 
@@ -352,8 +352,8 @@ class AclExtras
             $dir = new Folder($path[0]);
             $controllers = $dir->find('.*Controller\.php');
         } else {
-            $path = App::path('Controller' . (empty($prefix) ? '' : DS . Inflector::camelize($prefix)), $plugin);
-            $dir = new Folder($path[0]);
+            $path = Plugin::classPath($plugin) . 'Controller' . DS. (empty($prefix) ? '' : DS . Inflector::camelize($prefix));
+            $dir = new Folder($path);
             $controllers = $dir->find('.*Controller\.php');
         }
 

--- a/src/Auth/ActionsAuthorize.php
+++ b/src/Auth/ActionsAuthorize.php
@@ -33,7 +33,7 @@ class ActionsAuthorize extends BaseAuthorize
      * @param \Cake\Network\Request $request The request needing authorization.
      * @return bool
      */
-    public function authorize($user, ServerRequest $request)
+    public function authorize($user, ServerRequest $request) :bool
     {
         $Acl = $this->_registry->load('Acl');
         $user = [$this->_config['userModel'] => $user];

--- a/src/Auth/CrudAuthorize.php
+++ b/src/Auth/CrudAuthorize.php
@@ -51,7 +51,7 @@ class CrudAuthorize extends BaseAuthorize
      * @param \Cake\Network\Request $request The request needing authorization.
      * @return bool
      */
-    public function authorize($user, ServerRequest $request)
+    public function authorize($user, ServerRequest $request) :bool
     {
         $mapped = $this->getConfig('actionMap.' . $request->getParam('action'));
 

--- a/src/Model/Table/AclNodesTable.php
+++ b/src/Model/Table/AclNodesTable.php
@@ -34,7 +34,7 @@ class AclNodesTable extends Table
      *
      * @return void
      */
-    public static function defaultConnectionName()
+    public static function defaultConnectionName() :string
     {
         return Configure::read('Acl.database');
     }

--- a/src/Model/Table/AcoActionsTable.php
+++ b/src/Model/Table/AcoActionsTable.php
@@ -29,7 +29,7 @@ class AcoActionsTable extends Table
      * @param array $config Configuration
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config) :void
     {
         $this->belongsTo('Acos', [
             'className' => App::className('Acl.AcosTable', 'Model/Table'),

--- a/src/Model/Table/AcosTable.php
+++ b/src/Model/Table/AcosTable.php
@@ -29,7 +29,7 @@ class AcosTable extends AclNodesTable
      * @param array $config Config
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config) :void
     {
         parent::initialize($config);
         $this->setAlias('Acos');

--- a/src/Model/Table/ArosTable.php
+++ b/src/Model/Table/ArosTable.php
@@ -29,7 +29,7 @@ class ArosTable extends AclNodesTable
      * @param array $config Config
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config) :void
     {
         parent::initialize($config);
         $this->setAlias('Aros');

--- a/src/Model/Table/PermissionsTable.php
+++ b/src/Model/Table/PermissionsTable.php
@@ -182,14 +182,14 @@ class PermissionsTable extends AclNodesTable
             $save = array_combine($permKeys, array_pad([], count($permKeys), $value));
         } else {
             if (!is_array($actions)) {
-                if ($actions{0} !== '_') {
+                if (substr($actions, 0, 1) !== '_') {
                     $actions = ['_' . $actions];
                 } else {
                     $actions = [$actions];
                 }
             }
             foreach ($actions as $action) {
-                if ($action{0} !== '_') {
+                if (substr($action, 0, 1) !== '_') {
                     $action = '_' . $action;
                 }
                 if (!in_array($action, $permKeys, true)) {
@@ -268,3 +268,4 @@ class PermissionsTable extends AclNodesTable
         return $newKeys;
     }
 }
+

--- a/src/Model/Table/PermissionsTable.php
+++ b/src/Model/Table/PermissionsTable.php
@@ -32,7 +32,7 @@ class PermissionsTable extends AclNodesTable
      * @param array $config Configuration
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config) :void
     {
         $this->setAlias('Permissions');
         $this->setTable('aros_acos');

--- a/src/Shell/AclExtrasShell.php
+++ b/src/Shell/AclExtrasShell.php
@@ -16,6 +16,7 @@ namespace Acl\Shell;
 
 use Acl\AclExtras;
 use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Database\Exception;
 use Cake\ORM\TableRegistry;
@@ -56,7 +57,7 @@ class AclExtrasShell extends Shell
      *
      * @return void
      */
-    public function startup()
+    public function startup() :void
     {
         parent::startup();
         $this->AclExtras->startup();
@@ -100,7 +101,7 @@ class AclExtrasShell extends Shell
      *
      * @return \Cake\Console\ConsoleOptionParser
      */
-    public function getOptionParser()
+    public function getOptionParser() :ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
 

--- a/src/Shell/AclShell.php
+++ b/src/Shell/AclShell.php
@@ -14,6 +14,7 @@
 namespace Acl\Shell;
 
 use Acl\Controller\Component\AclComponent;
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
@@ -56,7 +57,7 @@ class AclShell extends Shell
      *
      * @return void
      */
-    public function startup()
+    public function startup() :void
     {
         parent::startup();
         if (isset($this->params['connection'])) {
@@ -365,7 +366,7 @@ class AclShell extends Shell
      *
      * @return ConsoleOptionParser
      */
-    public function getOptionParser()
+    public function getOptionParser() :ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
 

--- a/tests/TestCase/AclExtrasTest.php
+++ b/tests/TestCase/AclExtrasTest.php
@@ -48,7 +48,7 @@ class AclExtrasTestCase extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() :void
     {
         parent::setUp();
         Configure::write('Acl.classname', 'DbAcl');
@@ -64,7 +64,7 @@ class AclExtrasTestCase extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown() :void
     {
         parent::tearDown();
         unset($this->Task);

--- a/tests/TestCase/AclShellTest.php
+++ b/tests/TestCase/AclShellTest.php
@@ -16,7 +16,7 @@ class AclShellTest extends TestCase
         'app.ArosAcos',
     ];
 
-    public function setUp()
+    public function setUp() :void
     {
         parent::setUp();
         $this->io = $this->getMockBuilder('Cake\Console\ConsoleIo')

--- a/tests/TestCase/Adapter/CacheDbAclTest.php
+++ b/tests/TestCase/Adapter/CacheDbAclTest.php
@@ -75,7 +75,7 @@ class CacheDbAclTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() :void
     {
         parent::setUp();
         Configure::write('Acl.classname', __NAMESPACE__ . '\CachedDbAclTwoTest');
@@ -94,7 +94,7 @@ class CacheDbAclTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown() :void
     {
         parent::tearDown();
         unset($this->Acl);

--- a/tests/TestCase/Adapter/DbAclTest.php
+++ b/tests/TestCase/Adapter/DbAclTest.php
@@ -40,7 +40,7 @@ class AroTwoTest extends ArosTable
      * @param array $config Configuration array
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config) :void
     {
         parent::initialize($config);
         $this->setAlias('AroTwoTest');
@@ -66,7 +66,7 @@ class AcoTwoTest extends AcosTable
      * @param array $config Configuration array
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config) :void
     {
         parent::initialize($config);
         $this->setAlias('AcoTwoTest');
@@ -92,7 +92,7 @@ class PermissionTwoTest extends PermissionsTable
      * @param array $config Configuration array
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config) :void
     {
         parent::initialize($config);
         $this->setAlias('PermissionTwoTest');
@@ -157,7 +157,7 @@ class DbAclTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() :void
     {
         parent::setUp();
         Configure::write('Acl.classname', __NAMESPACE__ . '\DbAclTwoTest');
@@ -183,7 +183,7 @@ class DbAclTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown() :void
     {
         parent::tearDown();
         unset($this->Acl);

--- a/tests/TestCase/Adapter/IniAclTest.php
+++ b/tests/TestCase/Adapter/IniAclTest.php
@@ -31,7 +31,7 @@ class IniAclTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() :void
     {
         parent::setUp();
         Configure::write('Acl.classname', 'IniAcl');

--- a/tests/TestCase/Adapter/PhpAclTest.php
+++ b/tests/TestCase/Adapter/PhpAclTest.php
@@ -33,7 +33,7 @@ class PhpAclTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() :void
     {
         parent::setUp();
         Configure::write('Acl.classname', 'PhpAcl');

--- a/tests/TestCase/Auth/ActionsAuthorizeTest.php
+++ b/tests/TestCase/Auth/ActionsAuthorizeTest.php
@@ -29,7 +29,7 @@ class ActionsAuthorizeTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() :void
     {
         parent::setUp();
         $this->controller = $this->getMockBuilder('Cake\Controller\Controller')

--- a/tests/TestCase/Auth/CrudAuthorizeTest.php
+++ b/tests/TestCase/Auth/CrudAuthorizeTest.php
@@ -31,7 +31,7 @@ class CrudAuthorizeTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() :void
     {
         parent::setUp();
         Configure::write('Routing.prefixes', []);

--- a/tests/TestCase/Controller/Component/AclComponentTest.php
+++ b/tests/TestCase/Controller/Component/AclComponentTest.php
@@ -30,7 +30,7 @@ class AclComponentTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() :void
     {
         parent::setUp();
         if (!class_exists('MockAclImplementation', false)) {
@@ -48,7 +48,7 @@ class AclComponentTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown() :void
     {
         parent::tearDown();
         unset($this->Acl);

--- a/tests/TestCase/Model/Behavior/AclBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/AclBehaviorTest.php
@@ -40,7 +40,7 @@ class AclPeople extends Table
      * @param array $config Configuration array
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config) :void
     {
         $this->setTable('people');
         $this->setEntityClass(__NAMESPACE__ . '\AclPerson');
@@ -97,7 +97,7 @@ class AclUsers extends Table
      * @param array $config Configuration array
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config) :void
     {
         $this->setTable('users');
         $this->setEntityClass(__NAMESPACE__ . '\AclUser');
@@ -130,7 +130,7 @@ class AclPosts extends Table
      * @param array $config Configuration array
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config) :void
     {
         $this->setTable('posts');
         $this->setEntityClass(__NAMESPACE__ . '\AclPost');
@@ -191,7 +191,7 @@ class AclBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() :void
     {
         parent::setUp();
         Configure::write('Acl.database', 'test');
@@ -220,7 +220,7 @@ class AclBehaviorTest extends TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown() :void
     {
         parent::tearDown();
         unset($this->Aro, $this->Aco);

--- a/tests/TestCase/Model/Table/AclNodesTest.php
+++ b/tests/TestCase/Model/Table/AclNodesTest.php
@@ -41,7 +41,7 @@ class DbAroTest extends ArosTable
      * @param array $config Configuration array
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config) :void
     {
         parent::initialize($config);
         $this->setAlias('DbAroTest');
@@ -68,7 +68,7 @@ class DbAcoTest extends AcosTable
      * @param array $config Configuration array
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config) :void
     {
         parent::initialize($config);
         $this->setAlias('DbAcoTest');
@@ -95,7 +95,7 @@ class DbPermissionTest extends PermissionsTable
      * @param array $config Configuration array
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config) :void
     {
         parent::initialize($config);
         $this->setAlias('DbPermissionTest');
@@ -124,7 +124,7 @@ class DbAcoActionTest extends AcoActionsTable
      * @param array $config Configuration array
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config) :void
     {
         $this->setTable('aco_actions');
         $this->belongsTo('DbAcoTest', [
@@ -189,7 +189,7 @@ class AclNodeTest extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp() :void
     {
         parent::setUp();
         Configure::write('Acl.classname', 'TestDbAcl');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,6 +18,10 @@ use Cake\Log\Log;
 
 require_once 'vendor/autoload.php';
 
+if (!defined('DS')) {
+    define('DS', DIRECTORY_SEPARATOR);
+}
+
 define('ROOT', dirname(__DIR__));
 define('APP_DIR', 'test_app');
 define('WEBROOT_DIR', 'webroot');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -100,9 +100,8 @@ Cache::setConfig([
 ]);
 
 // Ensure default test connection is defined
-if (!getenv('db_class')) {
-    putenv('db_class=Cake\Database\Driver\Sqlite');
-    putenv('db_dsn=sqlite::memory:');
+if (!getenv('db_dsn')) {
+    putenv('db_dsn=sqlite:///:memory:');
 }
 
 ConnectionManager::setConfig('test', [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,6 +12,7 @@
  */
 
 use Cake\Cache\Cache;
+use Cake\Chronos\Chronos;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
@@ -105,7 +106,6 @@ if (!getenv('db_dsn')) {
 }
 
 ConnectionManager::setConfig('test', ['url' => getenv('db_dsn')]);
-ConnectionManager::setConfig('test_custom_i18n_datasource', ['url' => getenv('db_dsn')]);
 
 Configure::write('Session', [
     'defaults' => 'php'
@@ -124,19 +124,4 @@ Log::setConfig([
     ]
 ]);
 
-if (class_exists('Carbon\Carbon')) {
-    Carbon\Carbon::setTestNow(Carbon\Carbon::now());
-} else {
-    Cake\Chronos\Chronos::setTestNow(Cake\Chronos\Chronos::now());
-    Cake\Chronos\MutableDateTime::setTestNow(Cake\Chronos\MutableDateTime::now());
-    Cake\Chronos\Date::setTestNow(Cake\Chronos\Date::now());
-    Cake\Chronos\MutableDate::setTestNow(Cake\Chronos\MutableDate::now());
-}
-
-if (class_exists('PHPUnit_Runner_Version')) {
-    class_alias('PHPUnit_Framework_TestResult', 'PHPUnit\Framework\TestResult');
-    class_alias('PHPUnit_Framework_Error', 'PHPUnit\Framework\Error\Error');
-    class_alias('PHPUnit_Framework_Error_Warning', 'PHPUnit\Framework\Error\Warning');
-    class_alias('PHPUnit_Framework_Error_Notice', 'PHPUnit\Framework\Error\Notice');
-    class_alias('PHPUnit_Framework_ExpectationFailedException', 'PHPUnit\Framework\ExpectationFailedException');
-}
+Chronos::setTestNow(Chronos::now());

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -104,16 +104,8 @@ if (!getenv('db_dsn')) {
     putenv('db_dsn=sqlite:///:memory:');
 }
 
-ConnectionManager::setConfig('test', [
-    'className' => 'Cake\Database\Connection',
-    'driver' => getenv('db_class'),
-    'dsn' => getenv('db_dsn'),
-    'database' => getenv('db_database'),
-    'username' => getenv('db_login'),
-    'password' => getenv('db_password'),
-    'timezone' => 'UTC',
-    'quoteIdentifiers' => getenv('quoteIdentifiers'),
-]);
+ConnectionManager::setConfig('test', ['url' => getenv('db_dsn')]);
+ConnectionManager::setConfig('test_custom_i18n_datasource', ['url' => getenv('db_dsn')]);
 
 Configure::write('Session', [
     'defaults' => 'php'


### PR DESCRIPTION
I have updated the ACL plugin for CakePHP 4.x.

In addition i created an example application which uses _Authentication_, _Authorization_ _ACL_ and _CakePdf_ as reference implementation:

https://github.com/nook24/blood-pressure