### PR TITLE
Improve assertions

### DIFF
--- a/tests/TestCase/AclExtrasTest.php
+++ b/tests/TestCase/AclExtrasTest.php
@@ -36,7 +36,7 @@ include dirname(__FILE__) . DS . 'test_plugin_admin_controllers.php';
  * AclExtras Shell Test case
  *
  */
-class AclExtrasTestCase extends TestCase
+class AclExtrasTest extends TestCase
 {
 
     public $fixtures = [
@@ -187,7 +187,7 @@ class AclExtrasTestCase extends TestCase
         $this->assertEquals($result[0]['alias'], 'Comments');
 
         $result = $Aco->find('children', ['for' => $result[0]['id']])->toArray();
-        $this->assertEquals(count($result), 3);
+        $this->assertCount(3, $result);
         $this->assertEquals($result[0]['alias'], 'add');
         $this->assertEquals($result[1]['alias'], 'index');
         $this->assertEquals($result[2]['alias'], 'delete');
@@ -195,22 +195,22 @@ class AclExtrasTestCase extends TestCase
         $result = $Aco->node('controllers/Posts')->toArray();
         $this->assertEquals($result[0]['alias'], 'Posts');
         $result = $Aco->find('children', ['for' => $result[0]['id']])->toArray();
-        $this->assertEquals(count($result), 3);
+        $this->assertCount(3, $result);
 
         $result = $Aco->node('controllers/Admin/Posts')->toArray();
         $this->assertEquals($result[0]['alias'], 'Posts');
         $result = $Aco->find('children', ['for' => $result[0]['id']])->toArray();
-        $this->assertEquals(count($result), 3);
+        $this->assertCount(3, $result);
 
         $result = $Aco->node('controllers/Admin/BigLongNames')->toArray();
         $this->assertEquals($result[0]['alias'], 'BigLongNames');
         $result = $Aco->find('children', ['for' => $result[0]['id']])->toArray();
-        $this->assertEquals(count($result), 4);
+        $this->assertCount(4, $result);
 
         $result = $Aco->node('controllers/BigLongNames')->toArray();
         $this->assertEquals($result[0]['alias'], 'BigLongNames');
         $result = $Aco->find('children', ['for' => $result[0]['id']])->toArray();
-        $this->assertEquals(count($result), 4);
+        $this->assertCount(4, $result);
     }
 
     /**
@@ -250,7 +250,7 @@ class AclExtrasTestCase extends TestCase
         $Aco->save($new);
 
         $children = $Aco->find('children', ['for' => $result[0]['id']])->toArray();
-        $this->assertEquals(count($children), $expected);
+        $this->assertCount($expected, $children);
 
         return $result;
     }
@@ -274,9 +274,9 @@ class AclExtrasTestCase extends TestCase
 
         $this->Task->acoSync();
         $children = $Aco->find('children', ['for' => $basic[0]['id']])->toArray();
-        $this->assertEquals(count($children), 3);
+        $this->assertCount(3, $children);
         $children = $Aco->find('children', ['for' => $adminPosts[0]['id']])->toArray();
-        $this->assertEquals(count($children), 3);
+        $this->assertCount(3, $children);
 
         $method = $Aco->node('controllers/Comments/someMethod');
         $this->assertFalse($method);
@@ -300,14 +300,14 @@ class AclExtrasTestCase extends TestCase
 
         $result = $Aco->node('controllers/Comments')->toArray();
         $children = $Aco->find('children', ['for' => $result[0]['id']])->toArray();
-        $this->assertEquals(count($children), 3);
+        $this->assertCount(3, $children);
 
         $Aco->delete($children[0]);
         $Aco->delete($children[1]);
         $this->Task->acoUpdate();
 
         $children = $Aco->find('children', ['for' => $result[0]['id']])->toArray();
-        $this->assertEquals(count($children), 3);
+        $this->assertCount(3, $children);
     }
 
     /**
@@ -392,7 +392,7 @@ class AclExtrasTestCase extends TestCase
         $result = $result->toArray();
         $this->assertEquals($result[0]['alias'], 'PluginTwo');
         $result = $Aco->find('children', ['for' => $result[0]['id']])->toArray();
-        $this->assertEquals(count($result), 3);
+        $this->assertCount(3, $result);
         $this->assertEquals($result[0]['alias'], 'index');
         $this->assertEquals($result[1]['alias'], 'add');
         $this->assertEquals($result[2]['alias'], 'edit');

--- a/tests/TestCase/Adapter/DbAclTest.php
+++ b/tests/TestCase/Adapter/DbAclTest.php
@@ -240,9 +240,9 @@ class DbAclTest extends TestCase
             'parent_id' => $parent->id,
         ]));
         $result = $this->Acl->Aro->findByAlias('Subordinate')->first();
-        $this->assertEquals('AroTwoTest', $result->getSource());
-        $this->assertEquals(16, $result->lft);
-        $this->assertEquals(17, $result->rght);
+        $this->assertSame('AroTwoTest', $result->getSource());
+        $this->assertSame(16, $result->lft);
+        $this->assertSame(17, $result->rght);
     }
 
     /**
@@ -405,7 +405,7 @@ class DbAclTest extends TestCase
             'contain' => 'AroTwoTest',
         ])->toArray();
         $expected = '-1';
-        $this->assertEquals($expected, $result[0]->_delete);
+        $this->assertSame($expected, $result[0]->_delete);
 
         $this->assertFalse($this->Acl->deny('Lumbergh', 'ROOT/tpsReports/DoesNotExist', 'create'));
     }

--- a/tests/TestCase/Adapter/PhpAclTest.php
+++ b/tests/TestCase/Adapter/PhpAclTest.php
@@ -90,19 +90,19 @@ class PhpAclTest extends TestCase
             'Role' => 'FooModel/role',
         ];
 
-        $this->assertEquals('Role/default', $this->Acl->Aro->resolve('Foo.bar'));
-        $this->assertEquals('User/hardy', $this->Acl->Aro->resolve('FooModel/hardy'));
-        $this->assertEquals('User/hardy', $this->Acl->Aro->resolve('hardy'));
-        $this->assertEquals('User/hardy', $this->Acl->Aro->resolve(['FooModel' => ['nickname' => 'hardy']]));
-        $this->assertEquals('Role/admin', $this->Acl->Aro->resolve(['FooModel' => ['role' => 'admin']]));
-        $this->assertEquals('Role/admin', $this->Acl->Aro->resolve('Role/admin'));
+        $this->assertSame('Role/default', $this->Acl->Aro->resolve('Foo.bar'));
+        $this->assertSame('User/hardy', $this->Acl->Aro->resolve('FooModel/hardy'));
+        $this->assertSame('User/hardy', $this->Acl->Aro->resolve('hardy'));
+        $this->assertSame('User/hardy', $this->Acl->Aro->resolve(['FooModel' => ['nickname' => 'hardy']]));
+        $this->assertSame('Role/admin', $this->Acl->Aro->resolve(['FooModel' => ['role' => 'admin']]));
+        $this->assertSame('Role/admin', $this->Acl->Aro->resolve('Role/admin'));
 
-        $this->assertEquals('Role/admin', $this->Acl->Aro->resolve('admin'));
-        $this->assertEquals('Role/admin', $this->Acl->Aro->resolve('FooModel/admin'));
-        $this->assertEquals('Role/accounting', $this->Acl->Aro->resolve('accounting'));
+        $this->assertSame('Role/admin', $this->Acl->Aro->resolve('admin'));
+        $this->assertSame('Role/admin', $this->Acl->Aro->resolve('FooModel/admin'));
+        $this->assertSame('Role/accounting', $this->Acl->Aro->resolve('accounting'));
 
-        $this->assertEquals(PhpAro::DEFAULT_ROLE, $this->Acl->Aro->resolve('bla'));
-        $this->assertEquals(PhpAro::DEFAULT_ROLE, $this->Acl->Aro->resolve(['FooModel' => ['role' => 'hardy']]));
+        $this->assertSame(PhpAro::DEFAULT_ROLE, $this->Acl->Aro->resolve('bla'));
+        $this->assertSame(PhpAro::DEFAULT_ROLE, $this->Acl->Aro->resolve(['FooModel' => ['role' => 'hardy']]));
     }
 
     /**
@@ -129,10 +129,10 @@ class PhpAclTest extends TestCase
             ],
         ];
         // group/1
-        $this->assertEquals('Role/admin', $this->Acl->Aro->resolve($user));
+        $this->assertSame('Role/admin', $this->Acl->Aro->resolve($user));
         // group/24
-        $this->assertEquals('Role/accounting', $this->Acl->Aro->resolve('Role/24'));
-        $this->assertEquals('Role/accounting', $this->Acl->Aro->resolve('24'));
+        $this->assertSame('Role/accounting', $this->Acl->Aro->resolve('Role/24'));
+        $this->assertSame('Role/accounting', $this->Acl->Aro->resolve('24'));
 
         // check department
         $user = [

--- a/tests/TestCase/Auth/ActionsAuthorizeTest.php
+++ b/tests/TestCase/Auth/ActionsAuthorizeTest.php
@@ -166,7 +166,7 @@ class ActionsAuthorizeTest extends TestCase
         ]);
 
         $result = $this->auth->action($request);
-        $this->assertEquals('controllers/Posts/index', $result);
+        $this->assertSame('controllers/Posts/index', $result);
     }
 
     /**
@@ -184,7 +184,7 @@ class ActionsAuthorizeTest extends TestCase
             'action' => 'index',
         ]);
         $result = $this->auth->action($request);
-        $this->assertEquals('controllers/Posts/index', $result);
+        $this->assertSame('controllers/Posts/index', $result);
     }
 
     /**
@@ -202,7 +202,7 @@ class ActionsAuthorizeTest extends TestCase
         ]);
 
         $result = $this->auth->action($request);
-        $this->assertEquals('controllers/DebugKit/Posts/index', $result);
+        $this->assertSame('controllers/DebugKit/Posts/index', $result);
     }
 
     public function testActionWithPluginAndPrefix()
@@ -216,7 +216,7 @@ class ActionsAuthorizeTest extends TestCase
         ]);
 
         $result = $this->auth->action($request);
-        $this->assertEquals('controllers/DebugKit/Admin/Posts/index', $result);
+        $this->assertSame('controllers/DebugKit/Admin/Posts/index', $result);
     }
 
     public function testActionWithPrefix()
@@ -230,6 +230,6 @@ class ActionsAuthorizeTest extends TestCase
         ]);
 
         $result = $this->auth->action($request);
-        $this->assertEquals('controllers/Admin/Posts/index', $result);
+        $this->assertSame('controllers/Admin/Posts/index', $result);
     }
 }

--- a/tests/TestCase/Model/Behavior/AclBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/AclBehaviorTest.php
@@ -236,11 +236,11 @@ class AclBehaviorTest extends TestCase
     public function testSetup()
     {
         $User = TableRegistry::getTableLocator()->get('AclUsers');
-        $this->assertEquals('requester', $User->behaviors()->Acl->getConfig('type'));
+        $this->assertSame('requester', $User->behaviors()->Acl->getConfig('type'));
         $this->assertTrue(is_object($User->Aro));
 
         $Post = TableRegistry::getTableLocator()->get('AclPosts');
-        $this->assertEquals('controlled', $Post->behaviors()->Acl->getConfig('type'));
+        $this->assertSame('controlled', $Post->behaviors()->Acl->getConfig('type'));
         $this->assertTrue(is_object($Post->Aco));
     }
 
@@ -255,7 +255,7 @@ class AclBehaviorTest extends TestCase
         $User = TableRegistry::getTableLocator()->get('AclPeople', [
             'className' => __NAMESPACE__ . '\AclPeople',
         ]);
-        $this->assertEquals('both', $User->behaviors()->Acl->getConfig('type'));
+        $this->assertSame('both', $User->behaviors()->Acl->getConfig('type'));
         $this->assertTrue(is_object($User->Aro));
         $this->assertTrue(is_object($User->Aco));
     }
@@ -280,8 +280,8 @@ class AclBehaviorTest extends TestCase
         ]);
         $this->assertTrue(is_object($query));
         $result = $query->first();
-        $this->assertEquals($Post->getAlias(), $result->model);
-        $this->assertEquals($saved->id, $result->foreign_key);
+        $this->assertSame($Post->getAlias(), $result->model);
+        $this->assertSame($saved->id, $result->foreign_key);
 
         $Person = TableRegistry::getTableLocator()->get('AclPeople');
         $Person->deleteAll(['name' => 'person']);
@@ -308,13 +308,13 @@ class AclBehaviorTest extends TestCase
         $result = $this->Aro->find('all', [
             'conditions' => ['model' => $Person->getAlias(), 'foreign_key' => $saved->id],
         ])->first();
-        $this->assertEquals(5, $result->parent_id);
+        $this->assertSame(5, $result->parent_id);
 
         $node = $Person->node(['model' => $Person->getAlias(), 'foreign_key' => 8], 'Aro');
-        $this->assertEquals(2, $node->count());
+        $this->assertSame(2, $node->count());
         $node = $node->toArray();
-        $this->assertEquals(5, $node[0]->parent_id);
-        $this->assertEquals(null, $node[1]->parent_id);
+        $this->assertSame(5, $node[0]->parent_id);
+        $this->assertNull($node[1]->parent_id);
 
         $aroData = $this->Aro->save(new AclPerson([
             'model' => $Person->getAlias(),
@@ -333,12 +333,12 @@ class AclBehaviorTest extends TestCase
         $result = $this->Aro->find('all', [
             'conditions' => ['model' => $Person->getAlias(), 'foreign_key' => $person->id],
         ])->first();
-        $this->assertEquals(7, $result->parent_id);
+        $this->assertSame(7, $result->parent_id);
 
         $node = $Person->node(['model' => $Person->getAlias(), 'foreign_key' => 8], 'Aro')->toArray();
-        $this->assertEquals(2, count($node));
-        $this->assertEquals(7, $node[0]->parent_id);
-        $this->assertEquals(null, $node[1]->parent_id);
+        $this->assertCount(2, $node);
+        $this->assertSame(7, $node[0]->parent_id);
+        $this->assertNull($node[1]->parent_id);
     }
 
     /**
@@ -370,7 +370,7 @@ class AclBehaviorTest extends TestCase
         $result = $this->Aro->find('all', [
             'conditions' => ['model' => $Person->getAlias(), 'foreign_key' => $person->id],
         ])->first();
-        $this->assertEquals(5, $result->parent_id);
+        $this->assertSame(5, $result->parent_id);
 
         $person = $Person->save(new AclPerson([
             'id' => $person->id,
@@ -381,7 +381,7 @@ class AclBehaviorTest extends TestCase
         $result = $this->Aro->find('all', [
             'conditions' => ['model' => $Person->getAlias(), 'foreign_key' => $person->id],
         ])->first();
-        $this->assertEquals(5, $result->parent_id);
+        $this->assertSame(5, $result->parent_id);
     }
 
     /**
@@ -413,9 +413,9 @@ class AclBehaviorTest extends TestCase
         ]));
         $node = $Person->node($person, 'Aro')->toArray();
 
-        $this->assertEquals(2, count($node));
-        $this->assertEquals(5, $node[0]->parent_id);
-        $this->assertEquals(null, $node[1]->parent_id);
+        $this->assertCount(2, $node);
+        $this->assertSame(5, $node[0]->parent_id);
+        $this->assertNull($node[1]->parent_id);
 
         $Person->delete($person);
         $result = $this->Aro->find('all', [
@@ -463,6 +463,6 @@ class AclBehaviorTest extends TestCase
 
         $person = new AclPerson(['id' => 2], ['source' => $Person->getAlias()]);
         $result = $Person->node($person, 'Aro');
-        $this->assertEquals(1, $result->count());
+        $this->assertSame(1, $result->count());
     }
 }

--- a/tests/TestCase/Model/Table/AclNodesTest.php
+++ b/tests/TestCase/Model/Table/AclNodesTest.php
@@ -218,59 +218,59 @@ class AclNodeTest extends TestCase
         $result = $Aco->node('Controller1');
         $result = $result->extract('id')->toArray();
         $expected = [2, 1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $Aco->node('Controller1/action1');
         $result = $result->extract('id')->toArray();
         $expected = [3, 2, 1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $Aco->node('Controller2/action1');
         $result = $result->extract('id')->toArray();
         $expected = [7, 6, 1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $Aco->node('Controller1/action2');
         $result = $result->extract('id')->toArray();
         $expected = [5, 2, 1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $Aco->node('Controller1/action1/record1');
         $result = $result->extract('id')->toArray();
         $expected = [4, 3, 2, 1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $Aco->node('Controller2/action1/record1');
         $result = $result->extract('id')->toArray();
         $expected = [8, 7, 6, 1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $Aco->node(8);
         $result = $result->extract('id')->toArray();
         $expected = [8, 7, 6, 1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $Aco->node(7);
         $result = $result->extract('id')->toArray();
         $expected = [7, 6, 1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $Aco->node(4);
         $result = $result->extract('id')->toArray();
         $expected = [4, 3, 2, 1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $result = $Aco->node(3);
         $result = $result->extract('id')->toArray();
         $expected = [3, 2, 1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $this->assertFalse($Aco->node('Controller2/action3'));
 
         $this->assertFalse($Aco->node('Controller2/action3/record5'));
 
         $result = $Aco->node('');
-        $this->assertEquals(null, $result);
+        $this->assertNull($result);
     }
 
     /**
@@ -282,7 +282,7 @@ class AclNodeTest extends TestCase
     {
         $Aco = TableRegistry::getTableLocator()->get('DbAcoTest');
         $nodes = $Aco->node('ROOT/Users');
-        $this->assertEquals(1, $nodes->toArray()[0]->parent_id, 'Parent id does not point at ROOT. %s');
+        $this->assertSame(1, $nodes->toArray()[0]->parent_id, 'Parent id does not point at ROOT. %s');
     }
 
     /**
@@ -297,12 +297,12 @@ class AclNodeTest extends TestCase
         Configure::write('DbAclbindMode', 'string');
         $result = $Aro->node(['DbAroTest' => ['id' => '1', 'foreign_key' => '1']])->extract('id')->toArray();
         $expected = [3, 2, 1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         Configure::write('DbAclbindMode', 'array');
         $result = $Aro->node(['DbAroTest' => ['id' => 4, 'foreign_key' => 2]])->extract('id')->toArray();
         $expected = [4];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -317,12 +317,12 @@ class AclNodeTest extends TestCase
         $Model->setSource('AuthUser');
         $result = $Aro->node($Model)->extract('id')->toArray();
         $expected = [3, 2, 1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $Model->id = 2;
         $result = $Aro->node($Model)->extract('id')->toArray();
         $expected = [4, 2, 1];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -354,7 +354,7 @@ class AclNodeTest extends TestCase
             ['id' => 1, 'parent_id' => null, 'model' => null, 'foreign_key' => null, 'alias' => 'Application', 'lft' => 1, 'rght' => 4, 'db_aro_test' => []],
             ['id' => 2, 'parent_id' => 1, 'model' => null, 'foreign_key' => null, 'alias' => 'Pages', 'lft' => 2, 'rght' => 3, 'db_aro_test' => []],
         ];
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     /**
@@ -375,12 +375,12 @@ class AclNodeTest extends TestCase
         $aro = $Aro->save($aro);
         $result = $aro->id;
         $expected = 5;
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
 
         $node = $Aro->node(['TestPlugin.TestPluginAuthUser' => ['id' => 1, 'user' => 'mariano']]);
         $result = $node->extract('id')->toArray();
         $expected = $aro->id;
-        $this->assertEquals($expected, $result[0]);
+        $this->assertSame($expected, $result[0]);
 
         $this->deprecated(function () {
             Plugin::unload('TestPlugin');


### PR DESCRIPTION
# Changed log

- The class name should be same as current PHP file name. Such as the `AclExtrasTest` class.
- Using the `assertCount` to assert result count is same as expected count number.
- Using the `assertSame` assertion to replace `assertEquals` and make assertions strict.
- Using the `assertNull` assertion to expected value is `null`.