### PR TITLE
fixed deprecation warning in PermissionsTable to work with CakePHP 4.3.x

### DIFF
--- a/src/Model/Table/PermissionsTable.php
+++ b/src/Model/Table/PermissionsTable.php
@@ -103,7 +103,7 @@ class PermissionsTable extends AclNodesTable
         }
 
         $inherited = [];
-        $acoIDs = $acoPath->extract('id')->toArray();
+        $acoIDs = $acoPath->all()->extract('id')->toArray();
 
         $count = $aroPath->count();
         $aroPaths = $aroPath->toArray();


### PR DESCRIPTION
there is an deprecation warning in the ACL Plugin since I have updated my Application from CakePHP 4.2.9 to CakePHP 4.3.0:

```
Deprecated (16384): Calling result set method `extract()` directly on query instance is deprecated. You must call `all()` to retrieve the results first. - /vendor/cakephp/acl/src/Model/Table/PermissionsTable.php, line: 104
 You can disable all deprecation warnings by setting `Error.errorLevel` to `E_ALL & ~E_USER_DEPRECATED`, or add `vendor/cakephp/acl/src/Model/Table/PermissionsTable.php` to  `Error.ignoredDeprecationPaths` in your `config/app.php` to mute deprecations from only this file. [CORE/src/Core/functions.php, line 322]
```

fixed with this pull request