### PR TITLE
Use 'Acl.' as plugin prefix and pluralized class name in ACL behavior

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/cakephp/acl"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "cakephp/cakephp": "^4.0",
         "cakephp/plugin-installer": "^1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "cakephp/acl",
+    "name": "itnovum/acl",
     "description": "Acl Plugin for CakePHP framework",
     "type": "cakephp-plugin",
     "keywords": [

--- a/src/Model/Behavior/AclBehavior.php
+++ b/src/Model/Behavior/AclBehavior.php
@@ -80,7 +80,8 @@ class AclBehavior extends Behavior
             if (!TableRegistry::getTableLocator()->exists($alias)) {
                 $config = ['className' => $className];
             }
-            $model->hasMany($type, [
+
+            $model->hasMany($alias, [
                 'targetTable' => TableRegistry::getTableLocator()->get($alias, $config),
             ]);
         }

--- a/src/Model/Behavior/AclBehavior.php
+++ b/src/Model/Behavior/AclBehavior.php
@@ -95,7 +95,7 @@ class AclBehavior extends Behavior
      * Retrieves the Aro/Aco node for this model
      *
      * @param string|array|Model $ref Array with 'model' and 'foreign_key', model object, or string value
-     * @param string $type Only needed when Acl is set up as 'both', specify 'Aro' or 'Aco' to get the correct node
+     * @param string $type Pluralized! Only needed when Acl is set up as 'both', specify 'Aros' or 'Acos' to get the correct node
      * @return \Cake\ORM\Query
      * @link http://book.cakephp.org/2.0/en/core-libraries/behaviors/acl.html#node
      * @throws \Cake\Core\Exception\Exception
@@ -114,7 +114,12 @@ class AclBehavior extends Behavior
             throw new Exception\Exception(__d('cake_dev', 'ref parameter must be a string or an Entity'));
         }
 
-        return $this->_table->{$type}->node($ref);
+        if(property_exists($this->_table, $type)){
+            return $this->_table->{$type}->node($ref);
+        }else{
+            $type = Inflector::pluralize($type);
+            return $this->_table->{$type}->node($ref);
+        }
     }
 
     /**
@@ -132,6 +137,7 @@ class AclBehavior extends Behavior
             $types = [$types];
         }
         foreach ($types as $type) {
+            $type = Inflector::pluralize($type);
             $parent = $entity->parentNode();
             if (!empty($parent)) {
                 $parent = $this->node($parent, $type)->first();
@@ -172,6 +178,7 @@ class AclBehavior extends Behavior
             $types = [$types];
         }
         foreach ($types as $type) {
+            $type = Inflector::pluralize($type);
             $node = $this->node($entity, $type)->toArray();
             if (!empty($node)) {
                 $event->getSubject()->{$type}->delete($node[0]);

--- a/src/Model/Behavior/AclBehavior.php
+++ b/src/Model/Behavior/AclBehavior.php
@@ -72,9 +72,9 @@ class AclBehavior extends Behavior
         }
         foreach ($types as $type) {
             $alias = Inflector::pluralize($type);
-            $className = App::className($alias . 'Table', 'Model/Table');
+            $className = App::className($alias, 'Model/Table', 'Table');
             if ($className == false) {
-                $className = App::className('Acl.' . $alias . 'Table', 'Model/Table');
+                $className = App::className('Acl.' . $alias, 'Model/Table', 'Table');
             }
             $config = [];
             if (!TableRegistry::getTableLocator()->exists($alias)) {

--- a/src/Model/Table/AclNodesTable.php
+++ b/src/Model/Table/AclNodesTable.php
@@ -57,7 +57,7 @@ class AclNodesTable extends Table
 
         if (empty($ref)) {
             return null;
-        } elseif (is_int($ref) || ctype_digit($ref)) {
+        } elseif (is_numeric($ref)) {
             $ref = [
                 'id' => $ref,
             ];

--- a/src/Model/Table/AcoActionsTable.php
+++ b/src/Model/Table/AcoActionsTable.php
@@ -34,7 +34,7 @@ class AcoActionsTable extends Table
     public function initialize(array $config) :void
     {
         $this->belongsTo('Acos', [
-            'className' => App::className('Acl.AcosTable', 'Model/Table'),
+            'className' => 'Acl.Acos'
         ]);
     }
 }

--- a/src/Model/Table/AcosTable.php
+++ b/src/Model/Table/AcosTable.php
@@ -39,13 +39,13 @@ class AcosTable extends AclNodesTable
         $this->addBehavior('Tree', ['type' => 'nested']);
 
         $this->belongsToMany('Aros', [
-            'through' => App::className('Acl.PermissionsTable', 'Model/Table'),
-            'className' => App::className('Acl.ArosTable', 'Model/Table'),
+            'through' => 'Acl.Permissions',
+            'className' => 'Acl.Aros',
         ]);
         $this->hasMany('AcoChildren', [
-            'className' => App::className('Acl.AcosTable', 'Model/Table'),
+            'className' => 'Acl.Acos',
             'foreignKey' => 'parent_id',
         ]);
-        $this->setEntityClass(App::className('Acl.Aco', 'Model/Entity'));
+        $this->setEntityClass('Acl.Aco');
     }
 }

--- a/src/Model/Table/ArosTable.php
+++ b/src/Model/Table/ArosTable.php
@@ -39,11 +39,11 @@ class ArosTable extends AclNodesTable
         $this->addBehavior('Tree', ['type' => 'nested']);
 
         $this->belongsToMany('Acos', [
-            'through' => App::className('Acl.PermissionsTable', 'Model/Table'),
-            'className' => App::className('Acl.AcosTable', 'Model/Table'),
+            'through' => 'Acl.Permissions',
+            'className' => 'Acl.Acos',
         ]);
         $this->hasMany('AroChildren', [
-            'className' => App::className('Acl.ArosTable', 'Model/Table'),
+            'className' => 'Acl.Aros',
             'foreignKey' => 'parent_id',
         ]);
 

--- a/src/Model/Table/PermissionsTable.php
+++ b/src/Model/Table/PermissionsTable.php
@@ -230,8 +230,8 @@ class PermissionsTable extends AclNodesTable
         if (empty($obj['Aro']) || empty($obj['Aco'])) {
             return false;
         }
-        $aro = $obj['Aro']->extract('id')->toArray();
-        $aco = $obj['Aco']->extract('id')->toArray();
+        $aro = $obj['Aro']->all()->extract('id')->toArray();
+        $aco = $obj['Aco']->all()->extract('id')->toArray();
         $aro = current($aro);
         $aco = current($aco);
         $alias = $this->getAlias();

--- a/src/Model/Table/PermissionsTable.php
+++ b/src/Model/Table/PermissionsTable.php
@@ -39,10 +39,10 @@ class PermissionsTable extends AclNodesTable
         $this->setAlias('Permissions');
         $this->setTable('aros_acos');
         $this->belongsTo('Aros', [
-            'className' => App::className('Acl.ArosTable', 'Model/Table'),
+            'className' => 'Acl.Aros'
         ]);
         $this->belongsTo('Acos', [
-            'className' => App::className('Acl.AcosTable', 'Model/Table'),
+            'className' => 'Acl.Acos'
         ]);
         $this->Aro = $this->Aros->getTarget();
         $this->Aco = $this->Acos->getTarget();


### PR DESCRIPTION
- The AclBehavior used the singular table name to add the `hasMany` association which leats to usage of the wrong table.

- I also replaced `App::className()` with `Acl.` because the Acl Plugin was using generic auto generated `Cake\ORM\Table` instead of `Acl\Model\Table\`
I checked some other CakePHP plugins and none of it was using `App::className()`