### PR TITLE
PHP 8.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/cakephp/acl"
     },
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "cakephp/cakephp": "^4.0",
         "cakephp/plugin-installer": "^1.2"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
         <ini name="memory_limit" value="-1"/>
         <ini name="apc.enable_cli" value="1"/>
 
+        <env name="FIXTURE_SCHEMA_METADATA" value="./tests/schema.php"/>
         <!-- SQLite
         <env name="db_class" value="Cake\Database\Driver\Sqlite"/>
         <env name="db_dsn" value="sqlite:///:memory:"/>
@@ -30,13 +31,9 @@
             <directory>./tests/TestCase/</directory>
         </testsuite>
     </testsuites>
-    <listeners>
-        <listener class="\Cake\TestSuite\Fixture\FixtureInjector" file="./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php">
-            <arguments>
-                <object class="\Cake\TestSuite\Fixture\FixtureManager" />
-            </arguments>
-        </listener>
-    </listeners>
+    <extensions>
+        <extension class="\Cake\TestSuite\Fixture\PHPUnitExtension" />
+    </extensions>
 
     <filter>
         <whitelist>

--- a/src/Model/Table/AclNodesTable.php
+++ b/src/Model/Table/AclNodesTable.php
@@ -57,7 +57,7 @@ class AclNodesTable extends Table
 
         if (empty($ref)) {
             return null;
-        } elseif (is_int($ref) || ctype_digit($ref)) {
+        } elseif (is_int($ref) || (is_string($ref) && ctype_digit($ref))) {
             $ref = [
                 'id' => $ref,
             ];

--- a/src/Model/Table/PermissionsTable.php
+++ b/src/Model/Table/PermissionsTable.php
@@ -230,8 +230,8 @@ class PermissionsTable extends AclNodesTable
         if (empty($obj['Aro']) || empty($obj['Aco'])) {
             return false;
         }
-        $aro = $obj['Aro']->extract('id')->toArray();
-        $aco = $obj['Aco']->extract('id')->toArray();
+        $aro = $obj['Aro']->all()->extract('id')->toArray();
+        $aco = $obj['Aco']->all()->extract('id')->toArray();
         $aro = current($aro);
         $aco = current($aco);
         $alias = $this->getAlias();

--- a/tests/Fixture/AcoActionsFixture.php
+++ b/tests/Fixture/AcoActionsFixture.php
@@ -25,22 +25,6 @@ class AcoActionsFixture extends TestFixture
 {
 
     /**
-     * fields property
-     *
-     * @var array
-     */
-    public $fields = [
-        'id' => ['type' => 'integer'],
-        'parent_id' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'model' => ['type' => 'string', 'default' => ''],
-        'foreign_key' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'alias' => ['type' => 'string', 'default' => ''],
-        'lft' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'rght' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
-    ];
-
-    /**
      * records property
      *
      * @var array

--- a/tests/Fixture/AcoTwosFixture.php
+++ b/tests/Fixture/AcoTwosFixture.php
@@ -25,22 +25,6 @@ class AcoTwosFixture extends TestFixture
 {
 
     /**
-     * fields property
-     *
-     * @var array
-     */
-    public $fields = [
-        'id' => ['type' => 'integer'],
-        'parent_id' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'model' => ['type' => 'string', 'null' => true],
-        'foreign_key' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'alias' => ['type' => 'string', 'default' => ''],
-        'lft' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'rght' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
-    ];
-
-    /**
      * records property
      *
      * @var array

--- a/tests/Fixture/AcosFixture.php
+++ b/tests/Fixture/AcosFixture.php
@@ -25,22 +25,6 @@ class AcosFixture extends TestFixture
 {
 
     /**
-     * fields property
-     *
-     * @var array
-     */
-    public $fields = [
-        'id' => ['type' => 'integer'],
-        'parent_id' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'model' => ['type' => 'string', 'null' => true],
-        'foreign_key' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'alias' => ['type' => 'string', 'default' => ''],
-        'lft' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'rght' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
-    ];
-
-    /**
      * records property
      *
      * @var array

--- a/tests/Fixture/AroTwosFixture.php
+++ b/tests/Fixture/AroTwosFixture.php
@@ -25,22 +25,6 @@ class AroTwosFixture extends TestFixture
 {
 
     /**
-     * fields property
-     *
-     * @var array
-     */
-    public $fields = [
-        'id' => ['type' => 'integer'],
-        'parent_id' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'model' => ['type' => 'string', 'null' => true],
-        'foreign_key' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'alias' => ['type' => 'string', 'default' => ''],
-        'lft' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'rght' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
-    ];
-
-    /**
      * records property
      *
      * @var array

--- a/tests/Fixture/ArosAcoTwosFixture.php
+++ b/tests/Fixture/ArosAcoTwosFixture.php
@@ -25,22 +25,6 @@ class ArosAcoTwosFixture extends TestFixture
 {
 
     /**
-     * fields property
-     *
-     * @var array
-     */
-    public $fields = [
-        'id' => ['type' => 'integer'],
-        'aro_id' => ['type' => 'integer', 'length' => 10, 'null' => false],
-        'aco_id' => ['type' => 'integer', 'length' => 10, 'null' => false],
-        '_create' => ['type' => 'string', 'length' => 2, 'default' => 0],
-        '_read' => ['type' => 'string', 'length' => 2, 'default' => 0],
-        '_update' => ['type' => 'string', 'length' => 2, 'default' => 0],
-        '_delete' => ['type' => 'string', 'length' => 2, 'default' => 0],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
-    ];
-
-    /**
      * records property
      *
      * @var array

--- a/tests/Fixture/ArosAcosFixture.php
+++ b/tests/Fixture/ArosAcosFixture.php
@@ -25,22 +25,6 @@ class ArosAcosFixture extends TestFixture
 {
 
     /**
-     * fields property
-     *
-     * @var array
-     */
-    public $fields = [
-        'id' => ['type' => 'integer'],
-        'aro_id' => ['type' => 'integer', 'length' => 10, 'null' => false],
-        'aco_id' => ['type' => 'integer', 'length' => 10, 'null' => false],
-        '_create' => ['type' => 'string', 'length' => 2, 'default' => 0],
-        '_read' => ['type' => 'string', 'length' => 2, 'default' => 0],
-        '_update' => ['type' => 'string', 'length' => 2, 'default' => 0],
-        '_delete' => ['type' => 'string', 'length' => 2, 'default' => 0],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
-    ];
-
-    /**
      * records property
      *
      * @var array

--- a/tests/Fixture/ArosFixture.php
+++ b/tests/Fixture/ArosFixture.php
@@ -25,22 +25,6 @@ class ArosFixture extends TestFixture
 {
 
     /**
-     * fields property
-     *
-     * @var array
-     */
-    public $fields = [
-        'id' => ['type' => 'integer'],
-        'parent_id' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'model' => ['type' => 'string', 'null' => true],
-        'foreign_key' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'alias' => ['type' => 'string', 'default' => ''],
-        'lft' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        'rght' => ['type' => 'integer', 'length' => 10, 'null' => true],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
-    ];
-
-    /**
      * records property
      *
      * @var array

--- a/tests/Fixture/PeopleFixture.php
+++ b/tests/Fixture/PeopleFixture.php
@@ -24,24 +24,6 @@ class PeopleFixture extends TestFixture
 {
 
     /**
-     * fields property
-     *
-     * @var array
-     */
-    public $fields = [
-        'id' => ['type' => 'integer', 'null' => false],
-        'name' => ['type' => 'string', 'null' => false, 'length' => 32],
-        'mother_id' => ['type' => 'integer', 'null' => false],
-        'father_id' => ['type' => 'integer', 'null' => false],
-        '_constraints' => [
-            'PRIMARY' => ['type' => 'primary', 'columns' => ['id']],
-        ],
-        '_indexes' => [
-            'mother_id' => ['type' => 'index', 'columns' => ['mother_id', 'father_id']],
-        ],
-    ];
-
-    /**
      * records property
      *
      * @var array

--- a/tests/TestCase/AclExtrasTest.php
+++ b/tests/TestCase/AclExtrasTest.php
@@ -368,12 +368,12 @@ class AclExtrasTest extends TestCase
      */
     public function testUpdateWithPlugins()
     {
-        $this->deprecated(function () {
-            Plugin::getCollection()->clear();
-            Plugin::getCollection()->add(new \TestPlugin\Plugin());
-            Plugin::getCollection()->add(new \Nested\TestPluginTwo\Plugin());
-            //Plugin::routes();
-        });
+
+        $this->clearPlugins();
+        $this->loadPlugins([
+            new \TestPlugin\Plugin(),
+            new \Nested\TestPluginTwo\Plugin()
+        ]);
         $this->_clean();
 
         $this->Task->expects($this->atLeast(3))
@@ -433,10 +433,9 @@ class AclExtrasTest extends TestCase
      */
     public function testSyncWithNestedPlugin()
     {
-        $this->deprecated(function () {
-            Plugin::getCollection()->clear();
-            Plugin::getCollection()->add(new \Nested\TestPluginTwo\Plugin());
-        });
+        $this->clearPlugins();
+        $this->loadPlugins([new \Nested\TestPluginTwo\Plugin()]);
+
         $this->_clean();
 
         $this->Task->expects($this->atLeast(2))

--- a/tests/TestCase/Model/Table/AclNodesTest.php
+++ b/tests/TestCase/Model/Table/AclNodesTest.php
@@ -250,7 +250,17 @@ class AclNodeTest extends TestCase
         $expected = [8, 7, 6, 1];
         $this->assertSame($expected, $result);
 
+        $result = $Aco->node("8");
+        $result = $result->all()->extract('id')->toArray();
+        $expected = [8, 7, 6, 1];
+        $this->assertSame($expected, $result);
+
         $result = $Aco->node(7);
+        $result = $result->all()->extract('id')->toArray();
+        $expected = [7, 6, 1];
+        $this->assertSame($expected, $result);
+
+        $result = $Aco->node("7");
         $result = $result->all()->extract('id')->toArray();
         $expected = [7, 6, 1];
         $this->assertSame($expected, $result);
@@ -260,7 +270,17 @@ class AclNodeTest extends TestCase
         $expected = [4, 3, 2, 1];
         $this->assertSame($expected, $result);
 
+        $result = $Aco->node("4");
+        $result = $result->all()->extract('id')->toArray();
+        $expected = [4, 3, 2, 1];
+        $this->assertSame($expected, $result);
+
         $result = $Aco->node(3);
+        $result = $result->all()->extract('id')->toArray();
+        $expected = [3, 2, 1];
+        $this->assertSame($expected, $result);
+
+        $result = $Aco->node("3");
         $result = $result->all()->extract('id')->toArray();
         $expected = [3, 2, 1];
         $this->assertSame($expected, $result);

--- a/tests/TestCase/Model/Table/AclNodesTest.php
+++ b/tests/TestCase/Model/Table/AclNodesTest.php
@@ -216,52 +216,52 @@ class AclNodeTest extends TestCase
         $Aco = TableRegistry::getTableLocator()->get('DbAcoTest');
 
         $result = $Aco->node('Controller1');
-        $result = $result->extract('id')->toArray();
+        $result = $result->all()->extract('id')->toArray();
         $expected = [2, 1];
         $this->assertSame($expected, $result);
 
         $result = $Aco->node('Controller1/action1');
-        $result = $result->extract('id')->toArray();
+        $result = $result->all()->extract('id')->toArray();
         $expected = [3, 2, 1];
         $this->assertSame($expected, $result);
 
         $result = $Aco->node('Controller2/action1');
-        $result = $result->extract('id')->toArray();
+        $result = $result->all()->extract('id')->toArray();
         $expected = [7, 6, 1];
         $this->assertSame($expected, $result);
 
         $result = $Aco->node('Controller1/action2');
-        $result = $result->extract('id')->toArray();
+        $result = $result->all()->extract('id')->toArray();
         $expected = [5, 2, 1];
         $this->assertSame($expected, $result);
 
         $result = $Aco->node('Controller1/action1/record1');
-        $result = $result->extract('id')->toArray();
+        $result = $result->all()->extract('id')->toArray();
         $expected = [4, 3, 2, 1];
         $this->assertSame($expected, $result);
 
         $result = $Aco->node('Controller2/action1/record1');
-        $result = $result->extract('id')->toArray();
+        $result = $result->all()->extract('id')->toArray();
         $expected = [8, 7, 6, 1];
         $this->assertSame($expected, $result);
 
         $result = $Aco->node(8);
-        $result = $result->extract('id')->toArray();
+        $result = $result->all()->extract('id')->toArray();
         $expected = [8, 7, 6, 1];
         $this->assertSame($expected, $result);
 
         $result = $Aco->node(7);
-        $result = $result->extract('id')->toArray();
+        $result = $result->all()->extract('id')->toArray();
         $expected = [7, 6, 1];
         $this->assertSame($expected, $result);
 
         $result = $Aco->node(4);
-        $result = $result->extract('id')->toArray();
+        $result = $result->all()->extract('id')->toArray();
         $expected = [4, 3, 2, 1];
         $this->assertSame($expected, $result);
 
         $result = $Aco->node(3);
-        $result = $result->extract('id')->toArray();
+        $result = $result->all()->extract('id')->toArray();
         $expected = [3, 2, 1];
         $this->assertSame($expected, $result);
 
@@ -295,12 +295,12 @@ class AclNodeTest extends TestCase
         $Aro = TableRegistry::getTableLocator()->get('DbAroTest');
         $Aro->setEntityClass(__NAMESPACE__ . '\DbAroUserTest');
         Configure::write('DbAclbindMode', 'string');
-        $result = $Aro->node(['DbAroTest' => ['id' => '1', 'foreign_key' => '1']])->extract('id')->toArray();
+        $result = $Aro->node(['DbAroTest' => ['id' => '1', 'foreign_key' => '1']])->all()->extract('id')->toArray();
         $expected = [3, 2, 1];
         $this->assertSame($expected, $result);
 
         Configure::write('DbAclbindMode', 'array');
-        $result = $Aro->node(['DbAroTest' => ['id' => 4, 'foreign_key' => 2]])->extract('id')->toArray();
+        $result = $Aro->node(['DbAroTest' => ['id' => 4, 'foreign_key' => 2]])->all()->extract('id')->toArray();
         $expected = [4];
         $this->assertSame($expected, $result);
     }
@@ -315,12 +315,12 @@ class AclNodeTest extends TestCase
         $Aro = TableRegistry::getTableLocator()->get('DbAroTest');
         $Model = new DbAroUserTest(['id' => 1]);
         $Model->setSource('AuthUser');
-        $result = $Aro->node($Model)->extract('id')->toArray();
+        $result = $Aro->node($Model)->all()->extract('id')->toArray();
         $expected = [3, 2, 1];
         $this->assertSame($expected, $result);
 
         $Model->id = 2;
-        $result = $Aro->node($Model)->extract('id')->toArray();
+        $result = $Aro->node($Model)->all()->extract('id')->toArray();
         $expected = [4, 2, 1];
         $this->assertSame($expected, $result);
     }
@@ -378,7 +378,7 @@ class AclNodeTest extends TestCase
         $this->assertSame($expected, $result);
 
         $node = $Aro->node(['TestPlugin.TestPluginAuthUser' => ['id' => 1, 'user' => 'mariano']]);
-        $result = $node->extract('id')->toArray();
+        $result = $node->all()->extract('id')->toArray();
         $expected = $aro->id;
         $this->assertSame($expected, $result[0]);
 

--- a/tests/TestCase/Model/Table/AclNodesTest.php
+++ b/tests/TestCase/Model/Table/AclNodesTest.php
@@ -364,9 +364,7 @@ class AclNodeTest extends TestCase
      */
     public function testNodeActionAuthorize()
     {
-        $this->deprecated(function () {
-            Plugin::getCollection()->add(new \TestPlugin\Plugin());
-        });
+        $this->loadPlugins([new \TestPlugin\Plugin()]);
 
         $Aro = TableRegistry::getTableLocator()->get('DbAroTest');
         $Aro->setEntityClass(App::className('TestPlugin.TestPluginAuthUser', 'Model/Entity'));
@@ -382,8 +380,6 @@ class AclNodeTest extends TestCase
         $expected = $aro->id;
         $this->assertSame($expected, $result[0]);
 
-        $this->deprecated(function () {
-            Plugin::getCollection()->clear();
-        });
+        $this->clearPlugins();
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,6 +17,7 @@ use Cake\Chronos\Chronos;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\Log\Log;
+use Cake\TestSuite\Fixture\SchemaLoader;
 
 require_once 'vendor/autoload.php';
 
@@ -115,3 +116,10 @@ Log::setConfig([
 ]);
 
 Chronos::setTestNow(Chronos::now());
+
+// Create test database schema
+if (env('FIXTURE_SCHEMA_METADATA')) {
+
+    $loader = new SchemaLoader();
+    $loader->loadInternalFile(env('FIXTURE_SCHEMA_METADATA'));
+}

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -1,0 +1,352 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Abstract schema for CakePHP tests.
+ *
+ * This format resembles the existing fixture schema
+ * and is converted to SQL via the Schema generation
+ * features of the Database package.
+ */
+
+/**
+ * Load CakePHP core test schema
+ */
+$core = include './vendor/cakephp/cakephp/tests/schema.php';
+
+return array_merge($core, [
+    [
+        'table' => 'aros',
+        'columns' => [
+            'id' => [
+                'type' => 'integer'
+            ],
+            'parent_id' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+            'model' => [
+                'type' => 'string',
+                'null' => true
+            ],
+            'foreign_key' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+            'alias' => [
+                'type' => 'string',
+                'default' => ''
+            ],
+            'lft' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+            'rght' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ]
+        ],
+        'constraints' => [
+            'primary' =>
+                [
+                    'type' => 'primary',
+                    'columns' => ['id']
+                ]
+        ]
+    ],
+    [
+        'table' => 'acos',
+        'columns' => [
+            'id' => [
+                'type' => 'integer'
+            ],
+            'parent_id' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+            'model' => [
+                'type' => 'string',
+                'null' => true
+            ],
+            'foreign_key' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+            'alias' => [
+                'type' => 'string',
+                'default' => ''
+            ],
+            'lft' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+            'rght' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ]
+        ],
+        'constraints' => [
+            'primary' =>
+                [
+                    'type' => 'primary',
+                    'columns' => ['id']
+                ]
+        ]
+    ],
+    [
+        'table' => 'aros_acos',
+        'columns' => [
+            'id' => [
+                'type' => 'integer'
+            ],
+            'aro_id' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => false
+            ],
+            'aco_id' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => false
+            ],
+            '_create' => [
+                'type' => 'string',
+                'length' => 2,
+                'default' => 0
+            ],
+            '_read' => [
+                'type' => 'string',
+                'length' => 2,
+                'default' => 0
+            ],
+            '_update' => [
+                'type' => 'string',
+                'length' => 2,
+                'default' => 0
+            ],
+            '_delete' => [
+                'type' => 'string',
+                'length' => 2,
+                'default' => 0
+            ],
+        ],
+        'constraints' => [
+            'primary' =>
+                [
+                    'type' => 'primary',
+                    'columns' => ['id']
+                ]
+        ]
+    ],
+    [
+        'table' => 'aco_actions',
+        'columns' => [
+            'id' => [
+                'type' => 'integer'
+            ],
+            'parent_id' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+            'model' => [
+                'type' => 'string',
+                'null' => true
+            ],
+            'foreign_key' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+            'alias' => [
+                'type' => 'string',
+                'default' => ''
+            ],
+            'lft' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+            'rght' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ]
+        ],
+        'constraints' => [
+            'primary' =>
+                ['type' => 'primary',
+                    'columns' => ['id']
+                ]
+        ]
+    ],
+    [
+        'table' => 'aco_twos',
+        'columns' => [
+            'id' => [
+                'type' => 'integer'
+            ],
+            'parent_id' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+            'model' => [
+                'type' => 'string',
+                'null' => true
+            ],
+            'foreign_key' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true],
+            'alias' => [
+                'type' => 'string',
+                'default' => ''
+            ],
+            'lft' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+            'rght' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id'
+                ]
+            ]
+        ],
+    ],
+    [
+        'table' => 'aro_twos',
+        'columns' => [
+            'id' => [
+                'type' => 'integer'
+            ],
+            'parent_id' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+            'model' => [
+                'type' => 'string',
+                'null' => true
+            ],
+            'foreign_key' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+            'alias' => [
+                'type' => 'string',
+                'default' => ''
+            ],
+            'lft' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+            'rght' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => true
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id'
+                ]
+            ]
+        ],
+    ],
+    [
+        'table' => 'aros_aco_twos',
+        'columns' => [
+            'id' => [
+                'type' => 'integer'
+            ],
+            'aro_id' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => false
+            ],
+            'aco_id' => [
+                'type' => 'integer',
+                'length' => 10,
+                'null' => false
+            ],
+            '_create' => [
+                'type' => 'string',
+                'length' => 2,
+                'default' => 0
+            ],
+            '_read' => [
+                'type' => 'string',
+                'length' => 2,
+                'default' => 0
+            ],
+            '_update' => [
+                'type' => 'string',
+                'length' => 2,
+                'default' => 0
+            ],
+            '_delete' => [
+                'type' => 'string',
+                'length' => 2,
+                'default' => 0
+            ],
+        ],
+        'constraints' => [
+            'primary' => [
+                'type' => 'primary',
+                'columns' => ['id']
+            ]
+        ],
+    ],
+    [
+        'table' => 'people',
+        'columns' => [
+            'id' => [
+                'type' => 'integer',
+                'null' => false
+            ],
+            'name' => [
+                'type' => 'string',
+                'null' => false,
+                'length' => 32
+            ],
+            'mother_id' => [
+                'type' => 'integer',
+                'null' => false
+            ],
+            'father_id' => [
+                'type' => 'integer',
+                'null' => false
+            ],
+        ],
+        'constraints' => [
+            'PRIMARY' => [
+                'type' => 'primary',
+                'columns' => [
+                    'id'
+                ]
+            ],
+        ],
+    ],
+]);

--- a/tests/test_app/Plugin/TestPlugin/config/routes.php
+++ b/tests/test_app/Plugin/TestPlugin/config/routes.php
@@ -1,7 +1,13 @@
 <?php
 
-\Cake\Routing\Router::plugin('TestPlugin', function ($routes) {
-    $routes->prefix('admin', function ($routes) {
-        $routes->fallbacks('DashedRoute');
+use Cake\Routing\RouteBuilder;
+
+return static function (RouteBuilder $routes) {
+
+    $routes->plugin('TestPlugin', function ($routes) {
+        $routes->prefix('admin', function ($routes) {
+            $routes->fallbacks('DashedRoute');
+        });
     });
-});
+};
+

--- a/tests/test_app/config/routes.php
+++ b/tests/test_app/config/routes.php
@@ -1,5 +1,10 @@
 <?php
 
-\Cake\Routing\Router::prefix('Admin', function ($routes) {
-    $routes->fallbacks('DashedRoute');
-});
+use Cake\Routing\RouteBuilder;
+
+return static function (RouteBuilder $routes) {
+
+    $routes->prefix('Admin', function ($routes) {
+        $routes->fallbacks('DashedRoute');
+    });
+};


### PR DESCRIPTION
- Fixed the PHP 8.1 deprecation of passing non-string to ctype_digit
- Updated testsuite to CakePHP 4.3+

**Refs**

 https://wiki.php.net/rfc/deprecations_php_8_1#ctype_function_family_accepts_int_parameters
 https://www.php.net/manual/en/function.ctype-digit.php