### PR TITLE
Fix PHP 8.2 dynamic properties deprecation notices

### DIFF
--- a/src/Adapter/DbAcl.php
+++ b/src/Adapter/DbAcl.php
@@ -19,7 +19,10 @@ use Acl\AclInterface;
 use Cake\Controller\Component;
 use Cake\Core\App;
 use Cake\ORM\TableRegistry;
-use Cake\ORM\Table;
+use Acl\Model\Table\PermissionsTable;
+use Acl\Model\Table\ArosTable;
+use Acl\Model\Table\AcosTable;
+
 
 /**
  * DbAcl implements an ACL control system in the database. ARO's and ACO's are
@@ -41,9 +44,9 @@ use Cake\ORM\Table;
  */
 class DbAcl implements AclInterface
 {
-    private Table $Permission;
-    private Table $Aro;
-    private Table $Aco;
+    private PermissionsTable $Permission;
+    private ArosTable $Aro;
+    private AcosTable $Aco;
 
     /**
      * Constructor

--- a/src/Adapter/DbAcl.php
+++ b/src/Adapter/DbAcl.php
@@ -19,6 +19,7 @@ use Acl\AclInterface;
 use Cake\Controller\Component;
 use Cake\Core\App;
 use Cake\ORM\TableRegistry;
+use Cake\ORM\Table;
 
 /**
  * DbAcl implements an ACL control system in the database. ARO's and ACO's are
@@ -40,6 +41,9 @@ use Cake\ORM\TableRegistry;
  */
 class DbAcl implements AclInterface
 {
+    private Table $Permission;
+    private Table $Aro;
+    private Table $Aco;
 
     /**
      * Constructor

--- a/src/Adapter/DbAcl.php
+++ b/src/Adapter/DbAcl.php
@@ -23,7 +23,6 @@ use Acl\Model\Table\PermissionsTable;
 use Acl\Model\Table\ArosTable;
 use Acl\Model\Table\AcosTable;
 
-
 /**
  * DbAcl implements an ACL control system in the database. ARO's and ACO's are
  * structured into trees and a linking table is used to define permissions. You

--- a/src/Model/Table/PermissionsTable.php
+++ b/src/Model/Table/PermissionsTable.php
@@ -27,6 +27,8 @@ use Cake\Utility\Hash;
  */
 class PermissionsTable extends AclNodesTable
 {
+    private Table $Aro;
+    private Table $Aco;
 
     /**
      * {@inheritDoc}

--- a/src/Model/Table/PermissionsTable.php
+++ b/src/Model/Table/PermissionsTable.php
@@ -20,6 +20,8 @@ use Cake\Core\Configure;
 use Cake\Core\Exception\Exception;
 use Cake\ORM\Table;
 use Cake\Utility\Hash;
+use Acl\Model\Table\ArosTable;
+use Acl\Model\Table\AcosTable;
 
 /**
  * Permissions linking AROs with ACOs
@@ -27,8 +29,8 @@ use Cake\Utility\Hash;
  */
 class PermissionsTable extends AclNodesTable
 {
-    private Table $Aro;
-    private Table $Aco;
+    private ArosTable $Aro;
+    private AcosTable $Aco;
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Fixing issue raised here
[https://github.com/cakephp/cakephp/issues/16158](https://github.com/cakephp/cakephp/issues/16158)

Dynamic properties are deprecated in PHP8.2
[https://php.watch/versions/8.2/dynamic-properties-deprecated](https://php.watch/versions/8.2/dynamic-properties-deprecated)